### PR TITLE
Update dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,30 +9,30 @@
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.16.8.tgz",
       "integrity": "sha1-aH7DQUBiSjvsKxqOqSaEeK6PO+M=",
       "requires": {
-        "@types/express": "4.0.39",
+        "@types/express": "4.11.0",
         "@types/node": "8.0.28"
       }
     },
     "@types/chai": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.0.4.tgz",
-      "integrity": "sha1-/oYxXZpmgn/usW9zvJVGiOyVDhg=",
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.0.10.tgz",
+      "integrity": "sha512-Ejh1AXTY8lm+x91X/yar3G2z4x9RyKwdTVdyyu7Xj3dNB35fMNCnEWqTO9FgS3zjzlRNqk1MruYhgb8yhRN9rA==",
       "dev": true
     },
     "@types/express": {
-      "version": "4.0.39",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.0.39.tgz",
-      "integrity": "sha1-FEHyHVKzO+jU+oqGXBWmqRzQ+gk=",
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.11.0.tgz",
+      "integrity": "sha512-N1Wdp3v4KmdO3W/CM7KXrDwM4xcVZjlHF2dAOs7sNrTUX8PY3G4n9NkaHlfjGFEfgFeHmRRjywoBd4VkujDs9w==",
       "requires": {
         "@types/body-parser": "1.16.8",
-        "@types/express-serve-static-core": "4.0.52",
-        "@types/serve-static": "1.7.32"
+        "@types/express-serve-static-core": "4.11.0",
+        "@types/serve-static": "1.13.1"
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.0.52",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.0.52.tgz",
-      "integrity": "sha512-UpN389YLcQEIn1t4Kxc8TlCrg43r6o8IcF57LvmbCGNhWzz0dEg4AaUsN6IHrrSjPzPmmJ1FLYXGPP/expXOWg==",
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.11.0.tgz",
+      "integrity": "sha512-hOi1QNb+4G+UjDt6CEJ6MjXHy+XceY7AxIa28U9HgJ80C+3gIbj7h5dJNxOI7PU3DO1LIhGP5Bs47Dbf5l8+MA==",
       "requires": {
         "@types/node": "8.0.28"
       }
@@ -46,21 +46,11 @@
       }
     },
     "@types/fs-extra": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-4.0.5.tgz",
-      "integrity": "sha512-tIG0GpHum5IFb8Qze/cSv0w/0gNzHB+MUDftTQaxenx46z50g51/MPkNLssLz9+uZLzCDd35bT9qtWOTXZ21Gw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-4.0.0.tgz",
+      "integrity": "sha512-PlKJw6ujJXLJjbvB3T0UCbY3jibKM6/Ya5cc9j1q+mYDeK3aR4Dp+20ZwxSuvJr9mIoPxp7+IL4aMOEvsscRTA==",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.28"
-      }
-    },
-    "@types/glob": {
-      "version": "5.0.33",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-5.0.33.tgz",
-      "integrity": "sha512-BcD4yyWz+qmCggaYMSFF0Xn7GkO6tgwm3Fh9Gxk/kQmEU3Z7flQTnVlMyKBUNvXXNTCCyjqK4XT4/2hLd1gQ2A==",
-      "dev": true,
-      "requires": {
-        "@types/minimatch": "2.0.29",
         "@types/node": "8.0.28"
       }
     },
@@ -70,20 +60,20 @@
       "integrity": "sha1-/1fHf6GrZxO7RGU03cTZeXB6Onk="
     },
     "@types/highlight.js": {
-      "version": "9.12.1",
-      "resolved": "https://registry.npmjs.org/@types/highlight.js/-/highlight.js-9.12.1.tgz",
-      "integrity": "sha512-rjk9iOMh8dwRzzaqP6t4uCNZOiKOfdyhC1tXxX8sX8DC9qgTKnqm1oGTmuy0zKz0SFZ3RzlmEO3VUwh+qUIgLQ==",
+      "version": "9.1.8",
+      "resolved": "https://registry.npmjs.org/@types/highlight.js/-/highlight.js-9.1.8.tgz",
+      "integrity": "sha1-0ifxi8uPPxh+FpZfJESFmgRol1g=",
       "dev": true
     },
     "@types/lodash": {
-      "version": "4.14.85",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.85.tgz",
-      "integrity": "sha512-HrZiwDl62if0z31+rB99CLlg7WzS7b+KmyW75XAHEl/ZG0De2ACo6skZ89Zh3jOWkjKObN0Apq3MUezg7u9NKQ=="
+      "version": "4.14.92",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.92.tgz",
+      "integrity": "sha512-cdvY1fyUGYgG7/i07a/sR5PnD6+Z+ljUrD0CNVf0qj645VvEdLNtZPjvCp4siPy3rQ/KRXMfUATIqi3+9x57Sw=="
     },
     "@types/marked": {
-      "version": "0.0.28",
-      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-0.0.28.tgz",
-      "integrity": "sha1-RLp1Tp+lFDJYPo6zCnxN0km1L6o=",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-0.3.0.tgz",
+      "integrity": "sha512-CSf9YWJdX1DkTNu9zcNtdCcn6hkRtB5ILjbhRId4ZOQqx30fXmdecuaXhugQL6eyrhuXtaHJ7PHI+Vm7k9ZJjg==",
       "dev": true
     },
     "@types/memory-cache": {
@@ -92,9 +82,9 @@
       "integrity": "sha1-tlSndXtcpJ0dSZvA5M5SpK/qLXE="
     },
     "@types/mime": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.1.tgz",
-      "integrity": "sha1-LPQpctCTHBBgx9X6Zif85r2Hby8="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.0.tgz",
+      "integrity": "sha512-A2TAGbTFdBw9azHbpVd+/FkdW2T6msN1uct1O9bH3vTerEHKZhTXJUQXy+hNq1B0RagfU8U+KBdqiZpxjhOUQA=="
     },
     "@types/minimatch": {
       "version": "2.0.29",
@@ -103,9 +93,9 @@
       "dev": true
     },
     "@types/mocha": {
-      "version": "2.2.44",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.44.tgz",
-      "integrity": "sha1-HUp5jlPzUhL9WtTQQFBiAXHNW14=",
+      "version": "2.2.46",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.46.tgz",
+      "integrity": "sha512-fwTTP5QLf4xHMkv7ovcKvmlLWX3GrxCa5DRQDOilVyYGCp+arZTAQJCy7/4GKezzYJjfWMpB/Cy4e8nrc9XioA==",
       "dev": true
     },
     "@types/mockery": {
@@ -137,46 +127,57 @@
       }
     },
     "@types/serve-static": {
-      "version": "1.7.32",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.7.32.tgz",
-      "integrity": "sha1-D2cy5NqwgTdx3Y/I/hSUDzRyi0w=",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.1.tgz",
+      "integrity": "sha512-jDMH+3BQPtvqZVIcsH700Dfi8Q3MIcEx16g/VdxjoqiGR/NntekB10xdBpirMKnPe9z2C5cBmL0vte0YttOr3Q==",
       "requires": {
-        "@types/express-serve-static-core": "4.0.52",
-        "@types/mime": "1.3.1"
+        "@types/express-serve-static-core": "4.11.0",
+        "@types/mime": "2.0.0"
       }
     },
     "@types/shelljs": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/@types/shelljs/-/shelljs-0.7.6.tgz",
-      "integrity": "sha512-u5yMnfjMnLIwoRJWkGF5amWEtoIsIjszpvopqB9Pz91/U2Q7C9hgiY/dDmpbyLH6UoYF4inDvvJwjqflcUhCAg==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@types/shelljs/-/shelljs-0.7.0.tgz",
+      "integrity": "sha1-IpwVfGvB5n1rmQ5sXhjb0v9Yz/A=",
       "dev": true,
       "requires": {
-        "@types/glob": "5.0.33",
         "@types/node": "8.0.28"
       }
     },
     "@types/sinon": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-2.3.7.tgz",
-      "integrity": "sha1-6Swv7TKX6uB4140doDKyZ4i0r4Y=",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-4.1.2.tgz",
+      "integrity": "sha512-fL6bJHYRzbw/7ofbKiJ65SOAasoe5mZhHNSYKxWsF3sGl/arhRwDPwXJqM1xofKNTQD14HNX9VruicM7pm++mQ==",
+      "dev": true
+    },
+    "@types/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-FKjsOVbC6B7bdSB5CuzyHCkK69I=",
+      "dev": true
+    },
+    "@types/strip-json-comments": {
+      "version": "0.0.30",
+      "resolved": "https://registry.npmjs.org/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz",
+      "integrity": "sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==",
       "dev": true
     },
     "@types/superagent": {
-      "version": "3.5.5",
-      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-3.5.5.tgz",
-      "integrity": "sha1-9DeM7JEF3OX3SXnI5KH/P+GKWso=",
+      "version": "3.5.6",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-3.5.6.tgz",
+      "integrity": "sha512-yGiVkRbB1qtIkRCpEJIxlHazBoILmu33xbbu4IiwxTJjwDi/EudiPYAD7QwWe035jkE40yQgTVXZsAePFtleww==",
       "dev": true,
       "requires": {
         "@types/node": "8.0.28"
       }
     },
     "@types/supertest": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-2.0.3.tgz",
-      "integrity": "sha1-7crpJcQn3sanq+JpfuSwb7KWZME=",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-2.0.4.tgz",
+      "integrity": "sha512-0TvOJ+6XVMSImgqc2ClNllfVffCxHQhFbsbwOGzGTjdFydoaG052LPqnP8SnmSlnokOcQiPPcbz+Yi30LxWPyA==",
       "dev": true,
       "requires": {
-        "@types/superagent": "3.5.5"
+        "@types/superagent": "3.5.6"
       }
     },
     "@types/winston": {
@@ -217,7 +218,7 @@
       "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
       "dev": true,
       "requires": {
-        "color-convert": "1.9.0"
+        "color-convert": "1.9.1"
       }
     },
     "array-flatten": {
@@ -382,31 +383,14 @@
       }
     },
     "chalk": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-      "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+      "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
       "dev": true,
       "requires": {
         "ansi-styles": "3.2.0",
         "escape-string-regexp": "1.0.5",
         "supports-color": "4.4.0"
-      },
-      "dependencies": {
-        "has-flag": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "4.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
-          "dev": true,
-          "requires": {
-            "has-flag": "2.0.0"
-          }
-        }
       }
     },
     "check-error": {
@@ -440,9 +424,9 @@
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
     },
     "color-convert": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
-      "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
       "dev": true,
       "requires": {
         "color-name": "1.1.3"
@@ -466,6 +450,12 @@
       "requires": {
         "delayed-stream": "1.0.0"
       }
+    },
+    "commander": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+      "dev": true
     },
     "component-emitter": {
       "version": "1.2.1",
@@ -808,7 +798,7 @@
       "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
       "dev": true,
       "requires": {
-        "samsam": "1.2.1"
+        "samsam": "1.3.0"
       }
     },
     "formidable": {
@@ -818,13 +808,13 @@
       "dev": true
     },
     "fs-extra": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.1.tgz",
-      "integrity": "sha1-f8DGyJV/mD9X8waiTlud3Y0N2IA=",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
+      "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
       "dev": true,
       "requires": {
         "graceful-fs": "4.1.11",
-        "jsonfile": "3.0.1",
+        "jsonfile": "4.0.0",
         "universalify": "0.1.1"
       }
     },
@@ -856,9 +846,9 @@
       }
     },
     "glob": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-      "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
         "fs.realpath": "1.0.0",
@@ -875,6 +865,12 @@
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
       "dev": true
     },
+    "growl": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
+      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+      "dev": true
+    },
     "handlebars": {
       "version": "4.0.11",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
@@ -885,6 +881,12 @@
         "source-map": "0.4.4",
         "uglify-js": "2.8.29"
       }
+    },
+    "has-flag": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+      "dev": true
     },
     "he": {
       "version": "1.1.1",
@@ -897,6 +899,15 @@
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.12.0.tgz",
       "integrity": "sha1-5tnb5Xy+/mB1HwKvM2GVhwyQwB4=",
       "dev": true
+    },
+    "homedir-polyfill": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
+      "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
+      "dev": true,
+      "requires": {
+        "parse-passwd": "1.0.0"
+      }
     },
     "http-errors": {
       "version": "1.6.2",
@@ -925,9 +936,9 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "interpret": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
-      "integrity": "sha1-y8NcYu7uc/Gat7EKgBURQBr8D5A=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
+      "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
       "dev": true
     },
     "is-buffer": {
@@ -979,9 +990,9 @@
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "jsonfile": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
-      "integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
       "requires": {
         "graceful-fs": "4.1.11"
@@ -1004,6 +1015,12 @@
           "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         }
       }
+    },
+    "just-extend": {
+      "version": "1.1.27",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
+      "integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g==",
+      "dev": true
     },
     "kind-of": {
       "version": "3.2.2",
@@ -1030,21 +1047,27 @@
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
+    "lolex": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.3.1.tgz",
+      "integrity": "sha512-mQuW55GhduF3ppo+ZRUTz1PRjEh1hS5BbqU7d8D0ez2OKxHDod7StPPeAVKisZR5aLkHZjdGWSL42LSONUJsZw==",
+      "dev": true
+    },
     "longest": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
     },
     "make-error": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.0.tgz",
-      "integrity": "sha1-Uq06M5zPEM5itAQLcI/nByRLi5Y=",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.2.tgz",
+      "integrity": "sha512-l9ra35l5VWLF24y75Tg8XgfGLX0ueRhph118WKM6H5denx4bB5QF59+4UAm9oJ2qsPQZas/CQUDdtDdfvYHBdQ==",
       "dev": true
     },
     "marked": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
-      "integrity": "sha1-ssbGGPzOzk74bE/Gy4p8v1rtqNc=",
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.9.tgz",
+      "integrity": "sha512-nW5u0dxpXxHfkHzzrveY45gCbi+R4PaO4WRZYqZNl+vB0hVGeqlFn0aOg1c8AKL63TrNFn9Bm2UP4AdiZ9TPLw==",
       "dev": true
     },
     "media-typer": {
@@ -1112,9 +1135,9 @@
       }
     },
     "mocha": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.0.1.tgz",
-      "integrity": "sha1-Cu5alc9ppGGIIPXlH6MXFxF9rxs=",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
+      "integrity": "sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==",
       "dev": true,
       "requires": {
         "browser-stdout": "1.3.0",
@@ -1129,16 +1152,10 @@
         "supports-color": "4.4.0"
       },
       "dependencies": {
-        "commander": {
-          "version": "2.11.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-          "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
-          "dev": true
-        },
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -1147,7 +1164,7 @@
         "diff": {
           "version": "3.3.1",
           "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
-          "integrity": "sha1-qoVnpu7QPFMfyJ0/cRzQ5SWd7HU=",
+          "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
           "dev": true
         },
         "glob": {
@@ -1162,27 +1179,6 @@
             "minimatch": "3.0.4",
             "once": "1.4.0",
             "path-is-absolute": "1.0.1"
-          }
-        },
-        "growl": {
-          "version": "1.10.3",
-          "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
-          "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "4.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
-          "dev": true,
-          "requires": {
-            "has-flag": "2.0.0"
           }
         }
       }
@@ -1200,9 +1196,9 @@
       "dev": true
     },
     "moment": {
-      "version": "2.19.2",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.2.tgz",
-      "integrity": "sha512-Rf6jiHPEfxp9+dlzxPTmRHbvoFXsh2L/U8hOupUMpnuecHQmI6cF6lUbJl3QqKPko1u6ujO+FxtcajLVfLpAtA=="
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.20.1.tgz",
+      "integrity": "sha512-Yh9y73JRljxW5QxN08Fner68eFLxM5ynNOAw2LbIB1YAGeQzZT8QFSUvkAz609Zf+IHhhaUxqZK8dG3W/+HEvg=="
     },
     "ms": {
       "version": "2.0.0",
@@ -1213,6 +1209,36 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
+    },
+    "nise": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.2.0.tgz",
+      "integrity": "sha512-q9jXh3UNsMV28KeqI43ILz5+c3l+RiNW8mhurEwCKckuHQbL+hTJIKKTiUlCPKlgQ/OukFvSnKB/Jk3+sFbkGA==",
+      "dev": true,
+      "requires": {
+        "formatio": "1.2.0",
+        "just-extend": "1.1.27",
+        "lolex": "1.6.0",
+        "path-to-regexp": "1.7.0",
+        "text-encoding": "0.6.4"
+      },
+      "dependencies": {
+        "lolex": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
+          "integrity": "sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY=",
+          "dev": true
+        },
+        "path-to-regexp": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+          "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+          "dev": true,
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        }
+      }
     },
     "numeral": {
       "version": "2.0.6",
@@ -1249,6 +1275,12 @@
         "minimist": "0.0.10",
         "wordwrap": "0.0.3"
       }
+    },
+    "parse-passwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+      "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
+      "dev": true
     },
     "parseurl": {
       "version": "1.3.2",
@@ -1551,9 +1583,9 @@
       "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM="
     },
     "samsam": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.2.1.tgz",
-      "integrity": "sha1-7dOQk6MYQ3DLhZJDsr3yVefY6mc=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
+      "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
       "dev": true
     },
     "setprototypeof": {
@@ -1567,82 +1599,31 @@
       "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
       "dev": true,
       "requires": {
-        "glob": "7.1.1",
-        "interpret": "1.0.3",
+        "glob": "7.1.2",
+        "interpret": "1.1.0",
         "rechoir": "0.6.2"
       }
     },
     "sinon": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.1.2.tgz",
-      "integrity": "sha1-ZWEFIdkm+1N0LdhM1ZnwuJqC9EA=",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.1.3.tgz",
+      "integrity": "sha512-c7u0ZuvBRX1eXuB4jN3BRCAOGiUTlM8SE3TxbJHrNiHUKL7wonujMOB6Fi1gQc00U91IscFORQHDga/eccqpbw==",
       "dev": true,
       "requires": {
         "diff": "3.2.0",
         "formatio": "1.2.0",
         "lodash.get": "4.4.2",
-        "lolex": "2.3.0",
+        "lolex": "2.3.1",
         "nise": "1.2.0",
-        "supports-color": "4.5.0",
-        "type-detect": "4.0.3"
+        "supports-color": "4.4.0",
+        "type-detect": "4.0.5"
       },
       "dependencies": {
-        "has-flag": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+        "type-detect": {
+          "version": "4.0.5",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.5.tgz",
+          "integrity": "sha512-N9IvkQslUGYGC24RkJk1ba99foK6TkwC2FHAEBlQFBP0RxQZS8ZpJuAZcwiY/w9ZJHFQb1aOXBI60OdxhTrwEQ==",
           "dev": true
-        },
-        "just-extend": {
-          "version": "1.1.27",
-          "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
-          "integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g==",
-          "dev": true
-        },
-        "lolex": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.3.0.tgz",
-          "integrity": "sha512-rPO6R1t8PjYL6xbsFUg7aByKkWAql907na6powPBORVs4DCm8aMBUkL4+6CXO0gEIV8vtu3mWV0FB8ZaCYPBmA==",
-          "dev": true
-        },
-        "nise": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/nise/-/nise-1.2.0.tgz",
-          "integrity": "sha512-q9jXh3UNsMV28KeqI43ILz5+c3l+RiNW8mhurEwCKckuHQbL+hTJIKKTiUlCPKlgQ/OukFvSnKB/Jk3+sFbkGA==",
-          "dev": true,
-          "requires": {
-            "formatio": "1.2.0",
-            "just-extend": "1.1.27",
-            "lolex": "1.6.0",
-            "path-to-regexp": "1.7.0",
-            "text-encoding": "0.6.4"
-          },
-          "dependencies": {
-            "lolex": {
-              "version": "1.6.0",
-              "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
-              "integrity": "sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY=",
-              "dev": true
-            }
-          }
-        },
-        "path-to-regexp": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
-          "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
-          "dev": true,
-          "requires": {
-            "isarray": "0.0.1"
-          }
-        },
-        "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-          "dev": true,
-          "requires": {
-            "has-flag": "2.0.0"
-          }
         }
       }
     },
@@ -1655,18 +1636,18 @@
       }
     },
     "source-map-support": {
-      "version": "0.4.18",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-      "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.0.tgz",
+      "integrity": "sha512-vUoN3I7fHQe0R/SJLKRdKYuEdRGogsviXFkHHo17AWaTGv17VLnxw+CFXvqy+y4ORZ3doWLQcxRYfwKrsd/H7Q==",
       "dev": true,
       "requires": {
-        "source-map": "0.5.7"
+        "source-map": "0.6.1"
       },
       "dependencies": {
         "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         }
       }
@@ -1770,6 +1751,15 @@
         "superagent": "3.6.0"
       }
     },
+    "supports-color": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+      "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+      "dev": true,
+      "requires": {
+        "has-flag": "2.0.0"
+      }
+    },
     "text-encoding": {
       "version": "0.6.4",
       "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
@@ -1777,20 +1767,20 @@
       "dev": true
     },
     "ts-node": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-3.3.0.tgz",
-      "integrity": "sha1-wTxqMCTjC+EYDdUwOPwgkonUv2k=",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-4.1.0.tgz",
+      "integrity": "sha512-xcZH12oVg9PShKhy3UHyDmuDLV3y7iKwX25aMVPt1SIXSuAfWkFiGPEkg+th8R4YKW/QCxDoW7lJdb15lx6QWg==",
       "dev": true,
       "requires": {
         "arrify": "1.0.1",
-        "chalk": "2.1.0",
+        "chalk": "2.3.0",
         "diff": "3.2.0",
-        "make-error": "1.3.0",
+        "make-error": "1.3.2",
         "minimist": "1.2.0",
         "mkdirp": "0.5.1",
-        "source-map-support": "0.4.18",
-        "tsconfig": "6.0.0",
-        "v8flags": "3.0.0",
+        "source-map-support": "0.5.0",
+        "tsconfig": "7.0.0",
+        "v8flags": "3.0.1",
         "yn": "2.0.0"
       },
       "dependencies": {
@@ -1803,11 +1793,13 @@
       }
     },
     "tsconfig": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/tsconfig/-/tsconfig-6.0.0.tgz",
-      "integrity": "sha1-aw6DdgA9evGGT434+J3QBZ/80DI=",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/tsconfig/-/tsconfig-7.0.0.tgz",
+      "integrity": "sha512-vZXmzPrL+EmC4T/4rVlT2jNVMWCi/O4DIiSj3UHg1OE5kCKbk4mfrXc6dZksLgRM/TZlKnousKH9bbTazUWRRw==",
       "dev": true,
       "requires": {
+        "@types/strip-bom": "3.0.0",
+        "@types/strip-json-comments": "0.0.30",
         "strip-bom": "3.0.0",
         "strip-json-comments": "2.0.1"
       }
@@ -1842,23 +1834,23 @@
       }
     },
     "typedoc": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.8.0.tgz",
-      "integrity": "sha1-1xcrxqKZZPRRt2CcAFvq2t7+I2E=",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.9.0.tgz",
+      "integrity": "sha512-numP0CtcUK4I1Vssw6E1N/FjyJWpWqhLT4Zb7Gw3i7ca3ElnYh6z41Y/tcUhMsMYn6L8b67E/Fu4XYYKkNaLbA==",
       "dev": true,
       "requires": {
-        "@types/fs-extra": "4.0.5",
-        "@types/handlebars": "4.0.36",
-        "@types/highlight.js": "9.12.1",
-        "@types/lodash": "4.14.85",
-        "@types/marked": "0.0.28",
+        "@types/fs-extra": "4.0.0",
+        "@types/handlebars": "4.0.31",
+        "@types/highlight.js": "9.1.8",
+        "@types/lodash": "4.14.74",
+        "@types/marked": "0.3.0",
         "@types/minimatch": "2.0.29",
-        "@types/shelljs": "0.7.6",
-        "fs-extra": "4.0.1",
+        "@types/shelljs": "0.7.0",
+        "fs-extra": "4.0.3",
         "handlebars": "4.0.11",
         "highlight.js": "9.12.0",
         "lodash": "4.17.4",
-        "marked": "0.3.6",
+        "marked": "0.3.9",
         "minimatch": "3.0.4",
         "progress": "2.0.0",
         "shelljs": "0.7.8",
@@ -1866,6 +1858,18 @@
         "typescript": "2.4.1"
       },
       "dependencies": {
+        "@types/handlebars": {
+          "version": "4.0.31",
+          "resolved": "https://registry.npmjs.org/@types/handlebars/-/handlebars-4.0.31.tgz",
+          "integrity": "sha1-p/umb6/kJxOu6I7sqNuRGS7+bnI=",
+          "dev": true
+        },
+        "@types/lodash": {
+          "version": "4.14.74",
+          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.74.tgz",
+          "integrity": "sha512-BZknw3E/z3JmCLqQVANcR17okqVTPZdlxvcIz0fJiJVLUCbSH1hK3zs9r634PVSmrzAxN+n/fxlVRiYoArdOIQ==",
+          "dev": true
+        },
         "typescript": {
           "version": "2.4.1",
           "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.4.1.tgz",
@@ -1881,9 +1885,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.1.tgz",
-      "integrity": "sha1-7znN6ierrAtQAkLWcmq5DgyEZjE=",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.2.tgz",
+      "integrity": "sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q=",
       "dev": true
     },
     "uglify-js": {
@@ -1922,12 +1926,6 @@
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
     },
-    "user-home": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-      "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
-      "dev": true
-    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -1940,12 +1938,12 @@
       "integrity": "sha1-PdPT55Crwk17DToDT/q6vijrvAQ="
     },
     "v8flags": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.0.0.tgz",
-      "integrity": "sha512-AGl+C+4qpeSu2g3JxCD/mGFFOs/vVZ3XREkD3ibQXEqr4Y4zgIrPWW124/IKJFHOIVFIoH8miWrLf0o84HYjwA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.0.1.tgz",
+      "integrity": "sha1-3Oj8N5wX2fLJ6e142JzgAFKxt2s=",
       "dev": true,
       "requires": {
-        "user-home": "1.1.1"
+        "homedir-polyfill": "1.0.1"
       }
     },
     "verror": {

--- a/package.json
+++ b/package.json
@@ -8,15 +8,15 @@
   "scripts": {
     "test": "./test_sdk_and_examples.sh",
     "prepublishOnly": "tsc -p ./ --outDir build/",
-    "docs": "typedoc --out docs/ --mode modules --target es6 --module commonjs ./"
+    "docs": "typedoc --out docs/ --mode modules --target es6 --module commonjs ./src"
   },
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
     "@types/body-parser": "^1.16.8",
-    "@types/express": "^4.0.39",
+    "@types/express": "^4.11.0",
     "@types/handlebars": "^4.0.36",
-    "@types/lodash": "^4.14.85",
+    "@types/lodash": "^4.14.92",
     "@types/memory-cache": "0.2.0",
     "@types/request-promise-native": "^1.0.10",
     "@types/winston": "^2.3.7",
@@ -25,26 +25,26 @@
     "handlebars": "^4.0.11",
     "lodash": "^4.17.4",
     "memory-cache": "^0.2.0",
-    "moment": "^2.19.2",
+    "moment": "^2.20.1",
     "numeral": "^2.0.6",
     "request": "^2.83.0",
     "request-promise-native": "^1.0.5",
     "winston": "^2.4.0"
   },
   "devDependencies": {
-    "@types/chai": "^4.0.4",
-    "@types/mocha": "^2.2.44",
+    "@types/chai": "^4.0.10",
+    "@types/mocha": "^2.2.46",
     "@types/mockery": "^1.4.29",
-    "@types/sinon": "^2.3.7",
-    "@types/supertest": "^2.0.3",
+    "@types/sinon": "^4.1.2",
+    "@types/supertest": "^2.0.4",
     "chai": "^4.1.2",
-    "mocha": "^4.0.1",
+    "mocha": "^4.1.0",
     "mockery": "^2.1.0",
     "proxyquire": "^1.8.0",
-    "sinon": "^4.1.2",
+    "sinon": "^4.1.3",
     "supertest": "^3.0.0",
-    "ts-node": "^3.3.0",
-    "typedoc": "^0.8.0",
-    "typescript": "^2.6.1"
+    "ts-node": "^4.1.0",
+    "typedoc": "^0.9.0",
+    "typescript": "^2.6.2"
   }
 }

--- a/test_sdk_and_examples.sh
+++ b/test_sdk_and_examples.sh
@@ -1,15 +1,16 @@
 #!/bin/bash
-set -eu 
+set -eu
 
 rm -rf node_modules
 npm install
 npm run prepublishOnly
 
+export TS_NODE_TYPE_CHECK=1
 mocha -r ts-node/register src/tests/*.ts
 
 npm link
 
-for ex in examples/*; do  
+for ex in examples/*; do
     cd $ex
     if [ -f ./package.json ]; then
         rm -rf node_modules


### PR DESCRIPTION
This also remove a security warning: `typedoc` depends on `marked` which
has a known vulnerability in version 0.3.6 (now in version 0.3.9).
This is a dev dependency so the runtime wasn't affected by this CVE.