### PR TITLE
Fix overriding request options parameters in requestGatewayHelper

### DIFF
--- a/src/core/class/mediarithmics/common/BasePlugin.ts
+++ b/src/core/class/mediarithmics/common/BasePlugin.ts
@@ -130,7 +130,6 @@ export abstract class BasePlugin {
     let options = {
       method: method,
       uri: uri,
-      json: true,
       auth: {
         user: this.worker_id,
         pass: this.authentication_token,
@@ -159,15 +158,7 @@ export abstract class BasePlugin {
       : options;
 
     // Set the json flag if provided
-    options =
-      isJson !== undefined
-        ? Object.assign(
-            {
-              json: isJson
-            },
-            options
-          )
-        : options;
+    options.json = isJson !== undefined ? isJson : true;
 
     // Set the encoding to null if it is binary
     options = isBinary
@@ -189,10 +180,9 @@ export abstract class BasePlugin {
           isJson !== undefined && !isJson ? body : JSON.stringify(body);
         throw new Error(
           `Error while calling ${method} '${uri}' with the request body '${bodyString ||
-            ""}': got a ${e.response.statusCode} ${e.response
-            .statusMessage} with the response body ${JSON.stringify(
-            e.response.body
-          )}`
+            ""}': got a ${e.response.statusCode} ${
+            e.response.statusMessage
+          } with the response body ${JSON.stringify(e.response.body)}`
         );
       } else {
         this.logger.error(

--- a/src/core/class/mediarithmics/common/BasePlugin.ts
+++ b/src/core/class/mediarithmics/common/BasePlugin.ts
@@ -127,7 +127,7 @@ export abstract class BasePlugin {
     isJson?: boolean,
     isBinary?: boolean
   ) {
-    let options = {
+    let options: request.OptionsWithUri = {
       method: method,
       uri: uri,
       auth: {
@@ -138,37 +138,16 @@ export abstract class BasePlugin {
     };
 
     // Set the body if provided
-    options = body
-      ? Object.assign(
-          {
-            body: body
-          },
-          options
-        )
-      : options;
+    options.body = body !== undefined ? body : undefined;
 
     // Set the querystring if provided
-    options = qs
-      ? Object.assign(
-          {
-            qs: qs
-          },
-          options
-        )
-      : options;
+    options.qs = qs !== undefined ? qs : undefined;
 
     // Set the json flag if provided
     options.json = isJson !== undefined ? isJson : true;
 
     // Set the encoding to null if it is binary
-    options = isBinary
-      ? Object.assign(
-          {
-            encoding: null
-          },
-          options
-        )
-      : options;
+    options.encoding = (isBinary !== undefined || isBinary) ? null : undefined;
 
     this.logger.silly(`Doing gateway call with ${JSON.stringify(options)}`);
 


### PR DESCRIPTION
The arguments 'isJson' & isBinary are optional in requestGatewayHelper. When not given, they should have a default value.

Example with 'isJson': The previous implementation was setting the request option 'json' field to true by default before checking
wether isJson was defined (and if it was defined, what was its state).

The previous implementation tried to override the request option json field with Object.assign(). But, this is not what Object.assign()
is doing (or should be used for) => in case of overriding an already existing property, it is using the value of the last argument having it.

In our case, it was the initial 'options' variable which was provided last, hence we were keeping the default value of json => it was impossible to override
the json request property.

The same was happening for others request option properties. Now, it is fixed.