### PR TITLE
Fix typo

### DIFF
--- a/src/core/class/mediarithmics/common/BasePlugin.ts
+++ b/src/core/class/mediarithmics/common/BasePlugin.ts
@@ -147,7 +147,7 @@ export abstract class BasePlugin {
     options.json = isJson !== undefined ? isJson : true;
 
     // Set the encoding to null if it is binary
-    options.encoding = (isBinary !== undefined || isBinary) ? null : undefined;
+    options.encoding = (isBinary !== undefined && isBinary) ? null : undefined;
 
     this.logger.silly(`Doing gateway call with ${JSON.stringify(options)}`);
 


### PR DESCRIPTION
The encoding of request options object should be set to null only when isBinary is both defined AND if it is true.

The previous version had a 'OR' instead of an 'AND' in the expression...