### PR TITLE
Update API of ExternalSegmentCreation

### DIFF
--- a/src/core/interfaces/mediarithmics/api/audience-feed-connector/AudienceFeedConnectorPluginResponseInterface.ts
+++ b/src/core/interfaces/mediarithmics/api/audience-feed-connector/AudienceFeedConnectorPluginResponseInterface.ts
@@ -1,4 +1,5 @@
 export type AudienceFeedConnectorStatus = 'ok' | 'error';
+export declare type AudienceFeedConnectorConnectionStatus = 'ok' | 'error' | 'external_segment_not_ready_yet';
 
 export interface AudienceFeedConnectorPluginResponse {
   status: AudienceFeedConnectorStatus;
@@ -11,7 +12,7 @@ export interface ExternalSegmentCreationPluginResponse {
 }
 
 export interface ExternalSegmentConnectionPluginResponse {
-  status: AudienceFeedConnectorStatus;
+  status: AudienceFeedConnectorConnectionStatus;
   message?: string;
 }
 


### PR DESCRIPTION
When being called on the external_segment_connection endpoint, the plugins should now:
- Return 200 if everything was OK
- Return 502 if the external API is not OK yet (ex: segment is not fully ready on the 3rd party side)
- Return 500 if something else was wrong