### PR TITLE
Sanitize the Headers of the AdRenderer response

### DIFF
--- a/examples/handlebars-ad-renderer/src/tests/index.ts
+++ b/examples/handlebars-ad-renderer/src/tests/index.ts
@@ -604,10 +604,10 @@ describe("Test Example Handlebar Ad Renderer", function() {
 
                 recommendations.data.proposals.map((prop, idx) => {
                   expect(
-                    JSON.parse(headers).$clickable_contents[idx].item_id
+                    JSON.parse(decodeURIComponent(headers)).$clickable_contents[idx].item_id
                   ).to.be.eq(prop.$id);
                   expect(
-                    JSON.parse(headers).$clickable_contents[idx].$content_id
+                    JSON.parse(decodeURIComponent(headers)).$clickable_contents[idx].$content_id
                   ).to.be.eq(idx);
                 });
 

--- a/src/core/class/mediarithmics/ad-renderer/AdRendererBasePlugin.ts
+++ b/src/core/class/mediarithmics/ad-renderer/AdRendererBasePlugin.ts
@@ -147,7 +147,7 @@ export abstract class AdRendererBasePlugin<
             return res
               .header(
                 this.displayContextHeader,
-                JSON.stringify(adRendererResponse.displayContext)
+                encodeURIComponent(JSON.stringify(adRendererResponse.displayContext))
               )
               .status(200)
               .send(adRendererResponse.html);


### PR DESCRIPTION
Some HTTP clients / servers are accepting only a limited set of characters
in the HTTP Headers.

As we are letting our users provbide any value in the displayContext, we
need to sanitize their value before putting it im an HTTP Header.

URL Encoding seems a goog way to do that.