### PR TITLE
Fix invalid characters issues in the DisplayContext header

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
     "@types/fs-extra": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-4.0.0.tgz",
-      "integrity": "sha512-PlKJw6ujJXLJjbvB3T0UCbY3jibKM6/Ya5cc9j1q+mYDeK3aR4Dp+20ZwxSuvJr9mIoPxp7+IL4aMOEvsscRTA==",
+      "integrity": "sha1-HddCrVybzjCPelLQLrwBQhvJEC8=",
       "dev": true,
       "requires": {
         "@types/node": "8.0.28"
@@ -65,6 +65,12 @@
       "integrity": "sha1-0ifxi8uPPxh+FpZfJESFmgRol1g=",
       "dev": true
     },
+    "@types/jsesc": {
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@types/jsesc/-/jsesc-0.4.29.tgz",
+      "integrity": "sha1-2Ntltyd2mWwDhwMGpbBIwmmAz44=",
+      "dev": true
+    },
     "@types/lodash": {
       "version": "4.14.92",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.92.tgz",
@@ -73,7 +79,7 @@
     "@types/marked": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@types/marked/-/marked-0.3.0.tgz",
-      "integrity": "sha512-CSf9YWJdX1DkTNu9zcNtdCcn6hkRtB5ILjbhRId4ZOQqx30fXmdecuaXhugQL6eyrhuXtaHJ7PHI+Vm7k9ZJjg==",
+      "integrity": "sha1-WDwiPdMzhaHdoBqvd7DNBBHEtSQ=",
       "dev": true
     },
     "@types/memory-cache": {
@@ -84,7 +90,7 @@
     "@types/mime": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.0.tgz",
-      "integrity": "sha512-A2TAGbTFdBw9azHbpVd+/FkdW2T6msN1uct1O9bH3vTerEHKZhTXJUQXy+hNq1B0RagfU8U+KBdqiZpxjhOUQA=="
+      "integrity": "sha1-WnMG42fFObn2VDSZ3o3VGfrDeos="
     },
     "@types/minimatch": {
       "version": "2.0.29",
@@ -129,7 +135,7 @@
     "@types/serve-static": {
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.1.tgz",
-      "integrity": "sha512-jDMH+3BQPtvqZVIcsH700Dfi8Q3MIcEx16g/VdxjoqiGR/NntekB10xdBpirMKnPe9z2C5cBmL0vte0YttOr3Q==",
+      "integrity": "sha1-HSgB+mNdJ0zZfU7AfiayG0QSdJI=",
       "requires": {
         "@types/express-serve-static-core": "4.11.0",
         "@types/mime": "2.0.0"
@@ -159,7 +165,7 @@
     "@types/strip-json-comments": {
       "version": "0.0.30",
       "resolved": "https://registry.npmjs.org/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz",
-      "integrity": "sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==",
+      "integrity": "sha1-mqMMBNshKpoGSdaub9UKzMQHSKE=",
       "dev": true
     },
     "@types/superagent": {
@@ -174,7 +180,7 @@
     "@types/supertest": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-2.0.4.tgz",
-      "integrity": "sha512-0TvOJ+6XVMSImgqc2ClNllfVffCxHQhFbsbwOGzGTjdFydoaG052LPqnP8SnmSlnokOcQiPPcbz+Yi30LxWPyA==",
+      "integrity": "sha1-KHcOEykzZeJAqELX1cWhs9Le5ZM=",
       "dev": true,
       "requires": {
         "@types/superagent": "3.5.6"
@@ -426,7 +432,7 @@
     "color-convert": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
-      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+      "integrity": "sha1-wSYRB66y8pTr/+ye2eytUppgl+0=",
       "dev": true,
       "requires": {
         "color-name": "1.1.3"
@@ -454,7 +460,7 @@
     "commander": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+      "integrity": "sha1-FXFS/R56bI2YpbcVzzdt+SgARWM=",
       "dev": true
     },
     "component-emitter": {
@@ -810,7 +816,7 @@
     "fs-extra": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
-      "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+      "integrity": "sha1-DYUhIuW8W+tFP7Ao6cDJvzY0DJQ=",
       "dev": true,
       "requires": {
         "graceful-fs": "4.1.11",
@@ -848,7 +854,7 @@
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
       "dev": true,
       "requires": {
         "fs.realpath": "1.0.0",
@@ -868,7 +874,7 @@
     "growl": {
       "version": "1.10.3",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
-      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+      "integrity": "sha1-GSa6kM8+3+KttJJ/WIC8IsZseQ8=",
       "dev": true
     },
     "handlebars": {
@@ -974,6 +980,11 @@
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "optional": true
     },
+    "jsesc": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
+      "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4="
+    },
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
@@ -1019,7 +1030,7 @@
     "just-extend": {
       "version": "1.1.27",
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
-      "integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g==",
+      "integrity": "sha1-7G55QQ/5FORyZSq/oOYDwD1g6QU=",
       "dev": true
     },
     "kind-of": {
@@ -1137,7 +1148,7 @@
     "mocha": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
-      "integrity": "sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==",
+      "integrity": "sha1-fYbPvPNcuCnidUwy4XNV7AUzh5Q=",
       "dev": true,
       "requires": {
         "browser-stdout": "1.3.0",
@@ -1155,7 +1166,7 @@
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -1585,7 +1596,7 @@
     "samsam": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
-      "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
+      "integrity": "sha1-jR2TUOJWItow3j5EumkrUiGrfFA=",
       "dev": true
     },
     "setprototypeof": {
@@ -1647,7 +1658,7 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
           "dev": true
         }
       }
@@ -1754,7 +1765,7 @@
     "supports-color": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-      "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+      "integrity": "sha1-iD992rwWUUKyphQn8zUt7RldGj4=",
       "dev": true,
       "requires": {
         "has-flag": "2.0.0"
@@ -1769,7 +1780,7 @@
     "ts-node": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-4.1.0.tgz",
-      "integrity": "sha512-xcZH12oVg9PShKhy3UHyDmuDLV3y7iKwX25aMVPt1SIXSuAfWkFiGPEkg+th8R4YKW/QCxDoW7lJdb15lx6QWg==",
+      "integrity": "sha1-NtlSnHuQu5kzBsQIzQf3dD3iBxI=",
       "dev": true,
       "requires": {
         "arrify": "1.0.1",
@@ -1795,7 +1806,7 @@
     "tsconfig": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/tsconfig/-/tsconfig-7.0.0.tgz",
-      "integrity": "sha512-vZXmzPrL+EmC4T/4rVlT2jNVMWCi/O4DIiSj3UHg1OE5kCKbk4mfrXc6dZksLgRM/TZlKnousKH9bbTazUWRRw==",
+      "integrity": "sha1-hFOIdaTcIW5cSlQys6Tew9VOkbc=",
       "dev": true,
       "requires": {
         "@types/strip-bom": "3.0.0",
@@ -1836,7 +1847,7 @@
     "typedoc": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.9.0.tgz",
-      "integrity": "sha512-numP0CtcUK4I1Vssw6E1N/FjyJWpWqhLT4Zb7Gw3i7ca3ElnYh6z41Y/tcUhMsMYn6L8b67E/Fu4XYYKkNaLbA==",
+      "integrity": "sha1-FZv/fHeEzluR2G8+TMiSjmIECVc=",
       "dev": true,
       "requires": {
         "@types/fs-extra": "4.0.0",
@@ -1867,7 +1878,7 @@
         "@types/lodash": {
           "version": "4.14.74",
           "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.74.tgz",
-          "integrity": "sha512-BZknw3E/z3JmCLqQVANcR17okqVTPZdlxvcIz0fJiJVLUCbSH1hK3zs9r634PVSmrzAxN+n/fxlVRiYoArdOIQ==",
+          "integrity": "sha1-rDvY25iOf3A45dIr12p7oT+HYWg=",
           "dev": true
         },
         "typescript": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "body-parser": "^1.18.2",
     "express": "^4.16.2",
     "handlebars": "^4.0.11",
+    "jsesc": "^2.5.1",
     "lodash": "^4.17.4",
     "memory-cache": "^0.2.0",
     "moment": "^2.20.1",
@@ -33,6 +34,7 @@
   },
   "devDependencies": {
     "@types/chai": "^4.0.10",
+    "@types/jsesc": "^0.4.29",
     "@types/mocha": "^2.2.46",
     "@types/mockery": "^1.4.29",
     "@types/sinon": "^4.1.2",

--- a/src/core/class/mediarithmics/ad-renderer/AdRendererBasePlugin.ts
+++ b/src/core/class/mediarithmics/ad-renderer/AdRendererBasePlugin.ts
@@ -1,5 +1,6 @@
 import * as express from "express";
 import * as _ from "lodash";
+import * as jsesc from "jsesc";
 
 import {
   AdRendererRequest,
@@ -147,7 +148,7 @@ export abstract class AdRendererBasePlugin<
             return res
               .header(
                 this.displayContextHeader,
-                JSON.stringify(adRendererResponse.displayContext)
+                jsesc(adRendererResponse.displayContext, {json: true})
               )
               .status(200)
               .send(adRendererResponse.html);


### PR DESCRIPTION
We're putting some values passed by the plugin impl in an
HTTP Header in the AdRenderer plugin SDK.

The HTTP spec is asking to only put Latin1 characters. Node
throw an error when an invalid character is detected.

Using ACSII safe codes in our JSON should prevent any potential issues.