### PR TITLE
Fix Activity Analyzer types issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,8 @@ Testing Plugins is highly recommended.
 
 * `core.RecommandationsWrapper` have been renamed to `core.RecommendationsWrapper`
 
+* `core.UserActivityEvent` is now a `type`. If you were using it as a Class (ex: by extending it), you should now use `core.GenericUserActivityEvent` instead.
+
 
 ## Migration from 0.2.x to 0.3.x
 

--- a/examples/activity-analyzer/src/MyPluginImpl.ts
+++ b/examples/activity-analyzer/src/MyPluginImpl.ts
@@ -1,24 +1,40 @@
 import { core } from "@mediarithmics/plugins-nodejs-sdk";
 
+// Check that we can extend an Activity
+export interface MySuperActivity extends core.UserActivity {
+  cool_additional_property: string;
+}
+
+// Check that we can extend a Generic event
+export interface MySuperEvent extends core.GenericUserActivityEvent {
+  cool_additional_property: string;
+}
+
 export class MyActivityAnalyzerPlugin extends core.ActivityAnalyzerPlugin {
-    protected onActivityAnalysis(
-      request: core.ActivityAnalyzerRequest,
-      instanceContext: core.ActivityAnalyzerBaseInstanceContext
-    ): Promise<core.ActivityAnalyzerPluginResponse> {
-      const updatedActivity = request.activity;
-      const response: core.ActivityAnalyzerPluginResponse = {
-        status: "ok",
-        data: null
-      };
-  
-      // We add a field on the processed activitynégative
-      updatedActivity.processed_by = `${instanceContext.activityAnalyzer
-        .group_id}:${instanceContext.activityAnalyzer
+
+  protected onActivityAnalysis(
+    request: core.ActivityAnalyzerRequest,
+    instanceContext: core.ActivityAnalyzerBaseInstanceContext
+  ): Promise<core.ActivityAnalyzerPluginResponse> {
+    const updatedActivity = request.activity;
+    const response: core.ActivityAnalyzerPluginResponse = {
+      status: "ok",
+      data: null
+    };
+
+    // We add a field on the processed activity
+    updatedActivity.processed_by = `${instanceContext.activityAnalyzer
+      .group_id}:${instanceContext.activityAnalyzer
         .artifact_id} v.${instanceContext.activityAnalyzer
-        .visit_analyzer_plugin_id}`;
-  
-      response.data = updatedActivity;
-  
-      return Promise.resolve(response);
-    }
+          .visit_analyzer_plugin_id}`;
+
+    // We rename the first event
+    updatedActivity.$events[0].$event_name = "hello";
+
+    response.data = updatedActivity;
+
+    updatedActivity.$events
+
+    return Promise.resolve(response);
   }
+}

--- a/src/mediarithmics/api/datamart/UserActivityInterface.ts
+++ b/src/mediarithmics/api/datamart/UserActivityInterface.ts
@@ -111,7 +111,7 @@ export interface ConversionProperties
     $goal_technical_name?: string;
 }
 
-export type EventName =
+export type PlatformName =
     '$ad_click'
     | '$ad_view'
     | '$conversion'
@@ -133,9 +133,11 @@ export type EventName =
     | '$email_unsubscribe'
     | '$email_complaint'
     | '$set_user_profile_properties'
-    | '$content_corrections'
-    | string
-    ;
+    | '$content_corrections';
+
+export type EventName =
+    PlatformName
+    | string;
 
 
 export type UserActivityEvent =

--- a/src/mediarithmics/api/datamart/UserActivityInterface.ts
+++ b/src/mediarithmics/api/datamart/UserActivityInterface.ts
@@ -111,7 +111,7 @@ export interface ConversionProperties
     $goal_technical_name?: string;
 }
 
-export type PlatformName =
+export type PlatformEventName =
     '$ad_click'
     | '$ad_view'
     | '$conversion'
@@ -136,7 +136,7 @@ export type PlatformName =
     | '$content_corrections';
 
 export type EventName =
-    PlatformName
+    PlatformEventName
     | string;
 
 

--- a/src/mediarithmics/api/datamart/UserActivityInterface.ts
+++ b/src/mediarithmics/api/datamart/UserActivityInterface.ts
@@ -134,6 +134,7 @@ export type EventName =
     | '$email_complaint'
     | '$set_user_profile_properties'
     | '$content_corrections'
+    | string
     ;
 
 
@@ -162,7 +163,6 @@ export interface ConversionEvent {
     $properties: ConversionProperties
 }
 
-//TOFIX
 export interface GenericUserActivityEvent {
     $ts: number;
     $event_name: EventName;


### PR DESCRIPTION
Since 0.4.0, it was impossible to:
- Use a custom event name
- Extend `core.UserActivityEvent` as a class (as it's now a type)

Hence, this commit is:
- Adding `string` as a possible EventName to let users use custom event
name
- Adding a new migration line in REAME.md to invite users to use
`core.GenericUserActivityEvent` instead of `core.UserActivityEvent` if
they are extending it.
- Adding those types operation in the Dummy Activity analyzer so that we
can check for any regression while developping new versions of the SDK.