### PR TITLE
Refactor some Instance Context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+# 0.6.0
+
+- Rename the `recommenderProperties` field to `properties` for Recommender support
+- Change the type of `properties` in the Instance Context of Audience Feed & Recommender from `PluginProperty[]` to `PropertiesWrapper`
+
 # 0.5.0 - 2018-07-03
 
 - Change the Template design (for AdRenderer and EmailRenderer). See `README.md`

--- a/src/mediarithmics/plugins/audience-feed-connector/AudienceFeedConnectorBasePlugin.ts
+++ b/src/mediarithmics/plugins/audience-feed-connector/AudienceFeedConnectorBasePlugin.ts
@@ -6,7 +6,7 @@ import {
     AudienceSegmentResource
 } from '../../api/core/audiencesegment/AudienceSegmentInterface';
 import {PluginProperty} from '../../';
-import {BasePlugin} from '../common';
+import {BasePlugin, PropertiesWrapper} from '../common';
 import {
     ExternalSegmentConnectionRequest,
     ExternalSegmentCreationRequest, UserSegmentUpdateRequest
@@ -20,7 +20,7 @@ import {
 
 export interface AudienceFeedConnectorBaseInstanceContext {
     feed: AudienceSegmentExternalFeedResource;
-    feedProperties: PluginProperty[];
+    feedProperties: PropertiesWrapper;
 }
 
 export abstract class AudienceFeedConnectorBasePlugin extends BasePlugin {
@@ -74,7 +74,7 @@ export abstract class AudienceFeedConnectorBasePlugin extends BasePlugin {
 
         const context: AudienceFeedConnectorBaseInstanceContext = {
             feed: audienceFeed,
-            feedProperties: audienceFeedProps
+            feedProperties: new PropertiesWrapper(audienceFeedProps)
         };
 
         return context;

--- a/src/mediarithmics/plugins/recommender/RecommenderBasePlugin.ts
+++ b/src/mediarithmics/plugins/recommender/RecommenderBasePlugin.ts
@@ -3,7 +3,7 @@ import * as _ from "lodash";
 import * as cache from "memory-cache";
 
 import {
-  BasePlugin
+  BasePlugin, PropertiesWrapper
 } from "../common/BasePlugin";
 
 import {PluginProperty} from "../../api/core/plugin/PluginPropertyInterface";
@@ -18,7 +18,7 @@ import {
 } from "../../api/plugin/recommender/RecommenderRequestInterface"
 
 export interface RecommenderBaseInstanceContext {
-  recommenderProperties: PluginProperty[];
+  properties: PropertiesWrapper;
 }
 
 export interface RecommenderPluginResponse extends RecommendationsWrapper {}
@@ -74,7 +74,7 @@ export abstract class RecommenderPlugin extends BasePlugin {
       );
 
     const context: RecommenderBaseInstanceContext = {
-      recommenderProperties: recommenderProps
+      properties: new PropertiesWrapper(recommenderProps)
     };
 
     return context;


### PR DESCRIPTION
- Rename the `recommenderProperties` field to `properties` for
Recommender support
- Change the type of `properties` in the Instance Context of Audience
Feed & Recommender from `PluginProperty[]` to `PropertiesWrapper`