### PR TITLE
Update compartment_id type

### DIFF
--- a/src/mediarithmics/api/datamart/UserActivityInterface.ts
+++ b/src/mediarithmics/api/datamart/UserActivityInterface.ts
@@ -29,7 +29,7 @@ export interface UserActivity
     $ttl?: number;
     $user_agent_id?: string;
     $user_account_id?: string;
-    $compartment_id?: number;
+    $compartment_id?: string;
     $email_hash?: EmailHash;
     $origin?: UserActivityOrigin;
     $location?: UserActivityLocation;

--- a/src/mediarithmics/api/reference/UserIdentifierInterface.ts
+++ b/src/mediarithmics/api/reference/UserIdentifierInterface.ts
@@ -28,7 +28,7 @@ export interface UserEmailIdentifierInfo extends UserIdentifierInfo {
 export interface UserAccountIdentifierInfo extends UserIdentifierInfo {
     user_account_id: string;
     creation_ts: TimeStamp;
-    compartment_id?: number;
+    compartment_id?: number; //To Be changed to `string` when the back will be updated
 }
 
 export interface UserAgentIdentifierInfo extends UserIdentifierInfo {


### PR DESCRIPTION
The compartment_id in the activities or events should be a `string` instead of a number.
I've updated the interface of api/datamart repository to reflect that.

Note that it should also be a string within the UserIdentifierInterface but as of today the back is using it as a `number`.
I've set a reminder in the code so that when the back is updated we'll also update the interface in the plugin sdk