### PR TITLE
Add variability in the instance context refresh interval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+# 0.7.6 - 2019-XX-XX
+
+- Add variability in the instance context refresh interval to avoid 'burst' on the Gateway API
+- Change the default refresh interval from 2 minutes to 10 minutes
+
 # 0.7.5 - 2019-03-08
 
 - Fix Handlebars typescript declaration conflicts

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mediarithmics/plugins-nodejs-sdk",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mediarithmics/plugins-nodejs-sdk",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "description": "This is the mediarithmics nodejs to help plugin developers bootstrapping their plugin without having to deal with most of the plugin boilerplate",
   "repository": "github:MEDIARITHMICS/plugins-nodejs-sdk",
   "main": "./lib/index.js",

--- a/src/mediarithmics/plugins/activity-analyzer/ActivityAnalyzerBasePlugin.ts
+++ b/src/mediarithmics/plugins/activity-analyzer/ActivityAnalyzerBasePlugin.ts
@@ -130,7 +130,7 @@ export abstract class ActivityAnalyzerPlugin extends BasePlugin {
                 this.instanceContextBuilder(
                   activityAnalyzerRequest.activity_analyzer_id
                 ),
-                this.INSTANCE_CONTEXT_CACHE_EXPIRATION
+                this.getInstanceContextCacheExpiration()
               );
             }
 

--- a/src/mediarithmics/plugins/ad-renderer/base/AdRendererBasePlugin.ts
+++ b/src/mediarithmics/plugins/ad-renderer/base/AdRendererBasePlugin.ts
@@ -140,7 +140,7 @@ export abstract class AdRendererBasePlugin<
               this.pluginCache.put(
                 adRendererRequest.creative_id,
                 this.instanceContextBuilder(adRendererRequest.creative_id, forceReload),
-                this.INSTANCE_CONTEXT_CACHE_EXPIRATION
+                this.getInstanceContextCacheExpiration()
               );
             }
 

--- a/src/mediarithmics/plugins/audience-feed-connector/AudienceFeedConnectorBasePlugin.ts
+++ b/src/mediarithmics/plugins/audience-feed-connector/AudienceFeedConnectorBasePlugin.ts
@@ -111,7 +111,7 @@ export abstract class AudienceFeedConnectorBasePlugin extends BasePlugin {
             this.pluginCache.put(
                 feedId,
                 this.instanceContextBuilder(feedId),
-                this.INSTANCE_CONTEXT_CACHE_EXPIRATION
+                this.getInstanceContextCacheExpiration()
             );
         }
 

--- a/src/mediarithmics/plugins/bid-optimizer/BidOptimizerBasePlugin.ts
+++ b/src/mediarithmics/plugins/bid-optimizer/BidOptimizerBasePlugin.ts
@@ -174,7 +174,7 @@ export abstract class BidOptimizerPlugin extends BasePlugin {
                 this.instanceContextBuilder(
                   bidOptimizerRequest.campaign_info.bid_optimizer_id
                 ),
-                this.INSTANCE_CONTEXT_CACHE_EXPIRATION
+                this.getInstanceContextCacheExpiration()
               );
             } // We init the specific route to listen for bid decisions requests
 

--- a/src/mediarithmics/plugins/common/BasePlugin.ts
+++ b/src/mediarithmics/plugins/common/BasePlugin.ts
@@ -125,6 +125,9 @@ export abstract class BasePlugin {
   multiThread: boolean = false;
 
   // Default cache is now 10 min to give some breathing to the Gateway
+  // Note: This will be private or completly remove in the next major release as a breaking change
+  // TODO: in 0.8.x+, make this private or remove it completly (this should no longer be overriden in plugin impl., 
+  // or we should implement a minimum threshold pattern)
   INSTANCE_CONTEXT_CACHE_EXPIRATION: number = 600000;
 
   pluginCache: any;

--- a/src/mediarithmics/plugins/common/BasePlugin.ts
+++ b/src/mediarithmics/plugins/common/BasePlugin.ts
@@ -124,7 +124,8 @@ export class PropertiesWrapper {
 export abstract class BasePlugin {
   multiThread: boolean = false;
 
-  INSTANCE_CONTEXT_CACHE_EXPIRATION: number = 120000;
+  // Default cache is now 10 min to give some breathing to the Gateway
+  INSTANCE_CONTEXT_CACHE_EXPIRATION: number = 600000;
 
   pluginCache: any;
 
@@ -143,6 +144,12 @@ export abstract class BasePlugin {
   _transport: any = rp;
 
   enableThrottling: boolean = false;// Log level update implementation
+
+  // The idea here is to add a random part in the instance cache expiration -> we add +0-10% variablity
+  // The objective is to stop having 'synchronized' instance context re-build that are putting some stress on the gateway due to burst of API calls
+  getInstanceContextCacheExpiration() {
+    return this.INSTANCE_CONTEXT_CACHE_EXPIRATION * (1 + 0.1 * Math.random());
+  }
 
   onLogLevelUpdate(level: string) {
     const logLevel = level.toLowerCase();

--- a/src/mediarithmics/plugins/email-renderer/base/EmailRendererBasePlugin.ts
+++ b/src/mediarithmics/plugins/email-renderer/base/EmailRendererBasePlugin.ts
@@ -109,7 +109,7 @@ export abstract class EmailRendererPlugin< T extends EmailRendererBaseInstanceCo
                   emailRenderRequest.creative_id,
                   forceReload
                 ),
-                this.INSTANCE_CONTEXT_CACHE_EXPIRATION
+                this.getInstanceContextCacheExpiration()
               );
             }
 

--- a/src/mediarithmics/plugins/email-router/EmailRouterBasePlugin.ts
+++ b/src/mediarithmics/plugins/email-router/EmailRouterBasePlugin.ts
@@ -65,7 +65,7 @@ export abstract class EmailRouterPlugin extends BasePlugin {
       this.pluginCache.put(
         emailRouterId,
         this.instanceContextBuilder(emailRouterId),
-        this.INSTANCE_CONTEXT_CACHE_EXPIRATION
+        this.getInstanceContextCacheExpiration()
       );
     }
 
@@ -149,7 +149,7 @@ export abstract class EmailRouterPlugin extends BasePlugin {
             this.pluginCache.put(
               emailCheckRequest.email_router_id,
               this.instanceContextBuilder(emailCheckRequest.email_router_id),
-              this.INSTANCE_CONTEXT_CACHE_EXPIRATION
+              this.getInstanceContextCacheExpiration()
             );
           }
 

--- a/src/mediarithmics/plugins/recommender/RecommenderBasePlugin.ts
+++ b/src/mediarithmics/plugins/recommender/RecommenderBasePlugin.ts
@@ -124,7 +124,7 @@ export abstract class RecommenderPlugin extends BasePlugin {
                 this.instanceContextBuilder(
                   recommenderRequest.recommender_id
                 ),
-                this.INSTANCE_CONTEXT_CACHE_EXPIRATION
+                this.getInstanceContextCacheExpiration()
               );
             }
 

--- a/src/tests/BasePluginTests.ts
+++ b/src/tests/BasePluginTests.ts
@@ -229,4 +229,24 @@ describe("Data File helper Tests", function() {
     });
 
   });
+
+});
+
+describe("Instance Context Expiration Tests", function() {
+
+  class MyFakePlugin extends core.BasePlugin {}
+
+  it("InstanceContextExpiration: Check Instance Context variability: should be less than 10%", function(
+    done
+  ) {
+
+    const plugin = new MyFakePlugin(false);
+
+    const refreshInterval = plugin.getInstanceContextCacheExpiration();
+
+    expect(refreshInterval).to.be.gte(plugin.INSTANCE_CONTEXT_CACHE_EXPIRATION);
+    expect(refreshInterval).to.be.lte(plugin.INSTANCE_CONTEXT_CACHE_EXPIRATION * 1.1);
+    done();
+  });
+
 });


### PR DESCRIPTION
In order to avoid having 'bursts' effects on the Gateway APIs calls that
are being done when the instance context is re-built, we're now adding
some variability in the refresh period (+10%).

We also updated the refresh period from 2min to 10min.

This should lower the Gateway API load and provide a better plugin
stability / performance.