### PR TITLE
Optimize FetchDataFile Helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# 0.7.6 - 2019-03-28
+
+- Optimize `fetchDataFile` helper with caching.
+
 # 0.7.4 - 2018-11-13
 
 - Fix undefined port proxy url

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mediarithmics/plugins-nodejs-sdk",
-  "version": "0.7.4",
+  "version": "0.7.6",
   "description": "This is the mediarithmics nodejs to help plugin developers bootstrapping their plugin without having to deal with most of the plugin boilerplate",
   "repository": "github:MEDIARITHMICS/plugins-nodejs-sdk",
   "main": "./lib/index.js",


### PR DESCRIPTION
### Goal
Optimize use of cache for datafile fetching (fetching is a heavy operation on plateform).
### Modification
`fetchDataFile` Helper will save datafile in cache and re-use it if API response is a no-change code.

