### PR TITLE
BasePlugin | Fix Logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# Next 
+
+- Fix this.logger and /log_level routes that were broken since winston 3.x upgrade.
+
 # 0.7.8 - 2019-07-29
 
 - Expose new helper method `itFactory` used to test an Activity Analyzer plugin.

--- a/src/mediarithmics/plugins/common/BasePlugin.ts
+++ b/src/mediarithmics/plugins/common/BasePlugin.ts
@@ -534,7 +534,7 @@ export abstract class BasePlugin {
     this.app.use(bodyParser.json({type: "*/*", limit: "5mb"}));
     
     this.logger = winston.createLogger();
-    this.logger.add(new winston.transports.Console({level:"info"}));
+    this.logger.add(new winston.transports.Console());
 
     this.pluginCache = cache;
     this.pluginCache.clear();


### PR DESCRIPTION
- Updating log level:  `/v1/log_level` method was broken since upgrade to wiston 3.x.
- Log_level was set up at the level of the transport object and then frozen. Now, it's by default set up at the level of the logger object, which allows us to modify it at runtime.

