### PR TITLE
MICS-DEV - Update Interfaces of onUserSegmentUpdate

### DIFF
--- a/src/mediarithmics/api/plugin/audiencefeedconnector/AudienceFeedConnectorPluginResponseInterface.ts
+++ b/src/mediarithmics/api/plugin/audiencefeedconnector/AudienceFeedConnectorPluginResponseInterface.ts
@@ -1,6 +1,6 @@
 export type AudienceFeedConnectorStatus = 'ok' | 'error';
 export declare type AudienceFeedConnectorConnectionStatus = 'ok' | 'error' | 'external_segment_not_ready_yet';
-export type AudienceFeedConnectorContentType = 'text/csv' | 'application/json' | 'text/plain';
+
 export interface AudienceFeedConnectorPluginResponse {
   status: AudienceFeedConnectorStatus;
   message?: string;
@@ -18,10 +18,18 @@ export interface ExternalSegmentConnectionPluginResponse {
 
 export interface UserSegmentUpdatePluginResponse {
   status: AudienceFeedConnectorStatus;
-  data?: {
+  data?: [{
+    destination_token?: string;
+    grouping_key?: string
+    content?: string;
+    binary_content?: BinaryType;
     line: string;
-    contentType: AudienceFeedConnectorContentType
-  };
+  }];
+  stats?: [{
+    identifier?: string;
+    sync_result?: string;
+    tags?: any
+  }];
   message?: string;
   nextMsgDelayInMs?: number;
 }

--- a/src/mediarithmics/api/plugin/audiencefeedconnector/AudienceFeedConnectorPluginResponseInterface.ts
+++ b/src/mediarithmics/api/plugin/audiencefeedconnector/AudienceFeedConnectorPluginResponseInterface.ts
@@ -23,7 +23,6 @@ export interface UserSegmentUpdatePluginResponse {
     grouping_key?: string
     content?: string;
     binary_content?: BinaryType;
-    line: string;
   }];
   stats?: [{
     identifier?: string;

--- a/src/mediarithmics/api/plugin/audiencefeedconnector/AudienceFeedConnectorPluginResponseInterface.ts
+++ b/src/mediarithmics/api/plugin/audiencefeedconnector/AudienceFeedConnectorPluginResponseInterface.ts
@@ -1,6 +1,6 @@
 export type AudienceFeedConnectorStatus = 'ok' | 'error';
 export declare type AudienceFeedConnectorConnectionStatus = 'ok' | 'error' | 'external_segment_not_ready_yet';
-
+export type AudienceFeedConnectorContentType = 'text/csv' | 'application/json' | 'text/plain';
 export interface AudienceFeedConnectorPluginResponse {
   status: AudienceFeedConnectorStatus;
   message?: string;
@@ -18,6 +18,10 @@ export interface ExternalSegmentConnectionPluginResponse {
 
 export interface UserSegmentUpdatePluginResponse {
   status: AudienceFeedConnectorStatus;
+  data?: {
+    line: string;
+    contentType: AudienceFeedConnectorContentType
+  };
   message?: string;
   nextMsgDelayInMs?: number;
 }


### PR DESCRIPTION
The Yoda team is working on enabling the file drop from the audience external feeds plugins.
It requires an update of the onUserSegmentUpdate to pass two new arguments that are 
- the line to be built
- the file content type

This PR aims at updating the interface of the method and provide a test to cover this.