### PR TITLE
Fix data & stats not passed to the plugin response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+# 0.7.12 - 2020-10-27
+- Fix : properly pass data and stats object in the onUserSegmentUpdate response
+
 # 0.7.11 - 2020-10-06
 
 - Update interface for the expected output of the onUserSegmentUpdate which optional parameters.

--- a/src/mediarithmics/api/plugin/audiencefeedconnector/AudienceFeedConnectorPluginResponseInterface.ts
+++ b/src/mediarithmics/api/plugin/audiencefeedconnector/AudienceFeedConnectorPluginResponseInterface.ts
@@ -3,6 +3,8 @@ export declare type AudienceFeedConnectorConnectionStatus = 'ok' | 'error' | 'ex
 
 export interface AudienceFeedConnectorPluginResponse {
   status: AudienceFeedConnectorStatus;
+  data?: UserSegmentUpdatePluginResponseData[];
+  stats?: UserSegmentUpdatePluginResponseStats[];
   message?: string;
 }
 
@@ -18,17 +20,21 @@ export interface ExternalSegmentConnectionPluginResponse {
 
 export interface UserSegmentUpdatePluginResponse {
   status: AudienceFeedConnectorStatus;
-  data?: [{
-    destination_token?: string;
-    grouping_key?: string
-    content?: string;
-    binary_content?: BinaryType;
-  }];
-  stats?: [{
-    identifier?: string;
-    sync_result?: string;
-    tags?: any
-  }];
+  data?: UserSegmentUpdatePluginResponseData[];
+  stats?: UserSegmentUpdatePluginResponseStats[];
   message?: string;
   nextMsgDelayInMs?: number;
+}
+
+export interface UserSegmentUpdatePluginResponseData {
+  destination_token?: string;
+  grouping_key?: string
+  content?: string;
+  binary_content?: BinaryType;
+}
+
+export interface UserSegmentUpdatePluginResponseStats {
+  identifier?: string;
+  sync_result?: string;
+  tags?: any
 }

--- a/src/mediarithmics/plugins/audience-feed-connector/AudienceFeedConnectorBasePlugin.ts
+++ b/src/mediarithmics/plugins/audience-feed-connector/AudienceFeedConnectorBasePlugin.ts
@@ -258,7 +258,7 @@ export abstract class AudienceFeedConnectorBasePlugin extends BasePlugin {
             request.feed_id
           );
 
-          const response = await this.onUserSegmentUpdate(
+          const response: UserSegmentUpdatePluginResponse = await this.onUserSegmentUpdate(
             request,
             instanceContext
           );
@@ -278,6 +278,14 @@ export abstract class AudienceFeedConnectorBasePlugin extends BasePlugin {
 
           if (response.message) {
             pluginResponse.message = response.message;
+          }
+
+          if (response.data) {
+              pluginResponse.data = response.data;
+          }
+
+          if (response.stats) {
+              pluginResponse.stats = response.stats;
           }
 
           let statusCode: number;

--- a/src/tests/AudienceFeedConnector.ts
+++ b/src/tests/AudienceFeedConnector.ts
@@ -30,7 +30,12 @@ class MyFakeAudienceFeedConnector extends core.AudienceFeedConnectorBasePlugin {
     instanceContext: core.AudienceFeedConnectorBaseInstanceContext
   ): Promise<core.UserSegmentUpdatePluginResponse> {
     const response: core.UserSegmentUpdatePluginResponse = {
-      status: 'ok'
+      status: 'ok',
+      data: [{
+        destination_token: "destToken",
+        grouping_key: "segId",
+        content: "my_string"
+      }]
     };
     return Promise.resolve(response);
   }
@@ -82,7 +87,7 @@ describe('Fetch Audience Feed Gateway API', () => {
   });
 });
 
-describe('External Audience Feed API test', function () {
+describe.only('External Audience Feed API test', function () {
   // All the magic is here
   const plugin = new MyFakeAudienceFeedConnector(false);
   let runner: core.TestingPluginRunner;
@@ -238,7 +243,7 @@ describe('External Audience Feed API test', function () {
               .send(userSegmentUpdateRequest)
               .end(function (err, res) {
                 expect(res.status).to.equal(200);
-
+                expect(JSON.parse(res.text).data).to.deep.equal([{"destination_token":"destToken", "grouping_key":"segId","content":"my_string"}])
                 expect(JSON.parse(res.text).status).to.be.eq('ok');
 
                 done();


### PR DESCRIPTION
when calling onUserSegmentUpdate init method, the code was building the plugin response manually.
New parameters have been added (data & stats) that were not computed.
I've updated the tests to reflect that also