### PR TITLE
MICS-DEV Enable the plugin to return 429 errorCode 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+# xxxxx - YYYY-MM-DD
+- Enable to return retry statusName (429 Status Code) for the onUserSegmentUpdate method for the Audience Feed Connector Plugin
+
 # 0.7.12 - 2020-10-27
 - Fix : properly pass data and stats object in the onUserSegmentUpdate response
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -655,7 +655,7 @@
     "deep-eql": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-      "integrity": "sha1-38lARACtHI/gI+faHfHBR8S0RN8=",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
       "dev": true,
       "requires": {
         "type-detect": "^4.0.0"
@@ -1462,7 +1462,7 @@
     "mockery": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mockery/-/mockery-2.1.0.tgz",
-      "integrity": "sha1-WwrvH/Vk8PgTlEXhZVNseQlxNHA=",
+      "integrity": "sha512-9VkOmxKlWXoDO/h1jDZaS4lH33aWfRiJiNT/tKj+8OGzrcFDLo8d0syGdbsc3Bc4GvRXPb+NMMvojotmuGJTvA==",
       "dev": true
     },
     "module-not-found-error": {

--- a/src/mediarithmics/api/plugin/audiencefeedconnector/AudienceFeedConnectorPluginResponseInterface.ts
+++ b/src/mediarithmics/api/plugin/audiencefeedconnector/AudienceFeedConnectorPluginResponseInterface.ts
@@ -1,6 +1,6 @@
-export type AudienceFeedConnectorStatus = 'ok' | 'error';
+export type AudienceFeedConnectorStatus = 'ok' | 'error' | 'retry';
 export declare type AudienceFeedConnectorConnectionStatus = 'ok' | 'error' | 'external_segment_not_ready_yet';
-
+export type AudienceFeedConnectorContentType = 'text/csv' | 'application/json' | 'text/plain';
 export interface AudienceFeedConnectorPluginResponse {
   status: AudienceFeedConnectorStatus;
   data?: UserSegmentUpdatePluginResponseData[];

--- a/src/mediarithmics/plugins/audience-feed-connector/AudienceFeedConnectorBasePlugin.ts
+++ b/src/mediarithmics/plugins/audience-feed-connector/AudienceFeedConnectorBasePlugin.ts
@@ -296,6 +296,9 @@ export abstract class AudienceFeedConnectorBasePlugin extends BasePlugin {
             case 'error':
               statusCode = 500;
               break;
+            case 'retry':
+              statusCode = 429;
+              break;
             default:
               statusCode = 500;
           }

--- a/src/tests/AudienceFeedConnector.ts
+++ b/src/tests/AudienceFeedConnector.ts
@@ -1,10 +1,10 @@
-import {expect} from 'chai';
+import { expect } from 'chai';
 import 'mocha';
-import {core} from '../';
+import { core } from '../';
 import * as request from 'supertest';
 import * as sinon from 'sinon';
 
-class MyFakeAudienceFeedConnector extends core.AudienceFeedConnectorBasePlugin {
+class MyFakeAudienceFeedConnector1 extends core.AudienceFeedConnectorBasePlugin {
   protected onExternalSegmentCreation(
     request: core.ExternalSegmentCreationRequest,
     instanceContext: core.AudienceFeedConnectorBaseInstanceContext
@@ -41,6 +41,38 @@ class MyFakeAudienceFeedConnector extends core.AudienceFeedConnectorBasePlugin {
   }
 }
 
+class MyFakeAudienceFeedConnector2 extends core.AudienceFeedConnectorBasePlugin {
+  protected onExternalSegmentCreation(
+    request: core.ExternalSegmentCreationRequest,
+    instanceContext: core.AudienceFeedConnectorBaseInstanceContext
+  ): Promise<core.ExternalSegmentCreationPluginResponse> {
+    const response: core.ExternalSegmentCreationPluginResponse = {
+      status: 'ok'
+    };
+    return Promise.resolve(response);
+  }
+
+  protected onExternalSegmentConnection(
+    request: core.ExternalSegmentConnectionRequest,
+    instanceContext: core.AudienceFeedConnectorBaseInstanceContext
+  ): Promise<core.ExternalSegmentConnectionPluginResponse> {
+    const response: core.ExternalSegmentConnectionPluginResponse = {
+      status: 'ok'
+    };
+    return Promise.resolve(response);
+  }
+
+  protected onUserSegmentUpdate(
+    request: core.UserSegmentUpdateRequest,
+    instanceContext: core.AudienceFeedConnectorBaseInstanceContext
+  ): Promise<core.UserSegmentUpdatePluginResponse> {
+    const response: core.UserSegmentUpdatePluginResponse = {
+      status: 'retry',
+    };
+    return Promise.resolve(response);
+  }
+}
+
 const rpMockup: sinon.SinonStub = sinon.stub().returns(
   new Promise((resolve, reject) => {
     resolve('Yolo');
@@ -49,7 +81,7 @@ const rpMockup: sinon.SinonStub = sinon.stub().returns(
 
 describe('Fetch Audience Feed Gateway API', () => {
   // All the magic is here
-  const plugin = new MyFakeAudienceFeedConnector(false);
+  const plugin = new MyFakeAudienceFeedConnector1(false);
   const runner = new core.TestingPluginRunner(plugin, rpMockup);
 
   it('Check that feed_id is passed correctly in fetchAudienceFeedProperties', function (
@@ -58,7 +90,7 @@ describe('Fetch Audience Feed Gateway API', () => {
     const fakeId = '42000000';
 
     // We try a call to the Gateway
-    (runner.plugin as MyFakeAudienceFeedConnector)
+    (runner.plugin as MyFakeAudienceFeedConnector1)
       .fetchAudienceFeedProperties(fakeId)
       .then(() => {
         expect(rpMockup.args[0][0].uri).to.be.eq(
@@ -75,7 +107,7 @@ describe('Fetch Audience Feed Gateway API', () => {
     const fakeId = '42000000';
 
     // We try a call to the Gateway
-    (runner.plugin as MyFakeAudienceFeedConnector)
+    (runner.plugin as MyFakeAudienceFeedConnector1)
       .fetchAudienceSegment(fakeId)
       .then(() => {
         expect(rpMockup.args[1][0].uri).to.be.eq(
@@ -87,141 +119,141 @@ describe('Fetch Audience Feed Gateway API', () => {
   });
 });
 
-describe.only('External Audience Feed API test', function () {
+describe('External Audience Feed API test', function () {
   // All the magic is here
-  const plugin = new MyFakeAudienceFeedConnector(false);
   let runner: core.TestingPluginRunner;
+  const rpMockup: sinon.SinonStub = sinon.stub();
 
+  const audienceFeed: core.DataResponse<core.AudienceSegmentExternalFeedResource> = {
+    status: 'ok',
+    data: {
+      id: '74',
+      plugin_id: '984',
+      organisation_id: '95',
+      group_id: 'com.mediarithmics.audience-feed',
+      artifact_id: 'awesome-audience-feed',
+      version_id: '1254'
+    }
+  };
+
+  rpMockup
+    .withArgs(
+      sinon.match.has(
+        'uri',
+        sinon.match(function (value: string) {
+          return (
+            value.match(/\/v1\/audience_segment_external_feeds\/(.){1,10}/) !==
+            null
+          );
+        })
+      )
+    )
+    .returns(audienceFeed);
+
+  const properties: core.DataListResponse<core.PluginProperty> = {
+    status: 'ok',
+    count: 1,
+    data: [
+      {
+        technical_name: 'hello_world',
+        value: {
+          value: 'Yay'
+        },
+        property_type: 'STRING',
+        origin: 'PLUGIN',
+        writable: true,
+        deletable: false
+      }
+    ]
+  };
+
+  rpMockup
+    .withArgs(
+      sinon.match.has(
+        'uri',
+        sinon.match(function (value: string) {
+          return (
+            value.match(/\/v1\/audience_segment_external_feeds\/(.){1,10}\/properties/) !==
+            null
+          );
+        })
+      )
+    )
+    .returns(properties);
+
+  const externalSegmentCreation: core.ExternalSegmentCreationRequest = {
+    feed_id: '42',
+    datamart_id: '1023',
+    segment_id: '451256'
+  };
+
+  const externalSegmentConnection: core.ExternalSegmentConnectionRequest = {
+    feed_id: '42',
+    datamart_id: '1023',
+    segment_id: '451256'
+  };
+
+  const userSegmentUpdateRequest: core.UserSegmentUpdateRequest = {
+    feed_id: '42',
+    session_id: '43',
+    datamart_id: '1023',
+    segment_id: '451256',
+    ts: 1254412,
+    operation: 'UPSERT',
+    user_identifiers: [
+      {
+        type: 'USER_POINT',
+        user_point_id: '26340584-f777-404c-82c5-56220667464b'
+      } as core.UserPointIdentifierInfo,
+      {
+        type: 'USER_ACCOUNT',
+        user_account_id: '914eb2aa50cef7f3a8705b6bb54e50bb',
+        creation_ts: 1493118667529
+      } as core.UserAccountIdentifierInfo,
+      {
+        type: 'USER_EMAIL',
+        hash: 'e2749f6f4d8104ec385a75490b587c86',
+        email: undefined,
+        operator: undefined,
+        creation_ts: 1493118667529,
+        last_activity_ts: 1493127642622,
+        providers: []
+      } as core.UserEmailIdentifierInfo,
+      {
+        type: 'USER_AGENT',
+        vector_id: 'vec:886742516',
+        device: {
+          form_factor: 'PERSONAL_COMPUTER',
+          os_family: 'MAC_OS',
+          browser_family: 'CHROME',
+          brand: undefined,
+          model: undefined,
+          os_version: undefined,
+          carrier: undefined
+        },
+        creation_ts: 1493118667529,
+        last_activity_ts: 1493126966889,
+        providers: [],
+        mappings: []
+      } as core.UserAgentIdentifierInfo
+    ]
+  };
   it('Check that the plugin is giving good results with a simple handler', function (
     done
   ) {
-    const rpMockup: sinon.SinonStub = sinon.stub();
 
-    const audienceFeed: core.DataResponse<core.AudienceSegmentExternalFeedResource> = {
-      status: 'ok',
-      data: {
-        id: '74',
-        plugin_id: '984',
-        organisation_id: '95',
-        group_id: 'com.mediarithmics.audience-feed',
-        artifact_id: 'awesome-audience-feed',
-        version_id: '1254'
-      }
-    };
 
-    rpMockup
-      .withArgs(
-        sinon.match.has(
-          'uri',
-          sinon.match(function (value: string) {
-            return (
-              value.match(/\/v1\/audience_segment_external_feeds\/(.){1,10}/) !==
-              null
-            );
-          })
-        )
-      )
-      .returns(audienceFeed);
 
-    const properties: core.DataListResponse<core.PluginProperty> = {
-      status: 'ok',
-      count: 1,
-      data: [
-        {
-          technical_name: 'hello_world',
-          value: {
-            value: 'Yay'
-          },
-          property_type: 'STRING',
-          origin: 'PLUGIN',
-          writable: true,
-          deletable: false
-        }
-      ]
-    };
 
-    rpMockup
-      .withArgs(
-        sinon.match.has(
-          'uri',
-          sinon.match(function (value: string) {
-            return (
-              value.match(/\/v1\/audience_segment_external_feeds\/(.){1,10}\/properties/) !==
-              null
-            );
-          })
-        )
-      )
-      .returns(properties);
-
+    const plugin = new MyFakeAudienceFeedConnector1(false);
     runner = new core.TestingPluginRunner(plugin, rpMockup);
-
     // We init the plugin
     request(runner.plugin.app)
       .post('/v1/init')
-      .send({authentication_token: 'Manny', worker_id: 'Calavera'})
+      .send({ authentication_token: 'Manny', worker_id: 'Calavera' })
       .end((err, res) => {
         expect(res.status).to.equal(200);
       });
-
-    const externalSegmentCreation: core.ExternalSegmentCreationRequest = {
-      feed_id: '42',
-      datamart_id: '1023',
-      segment_id: '451256'
-    };
-
-    const externalSegmentConnection: core.ExternalSegmentConnectionRequest = {
-      feed_id: '42',
-      datamart_id: '1023',
-      segment_id: '451256'
-    };
-
-    const userSegmentUpdateRequest: core.UserSegmentUpdateRequest = {
-      feed_id: '42',
-      session_id: '43',
-      datamart_id: '1023',
-      segment_id: '451256',
-      ts: 1254412,
-      operation: 'UPSERT',
-      user_identifiers: [
-        {
-          type: 'USER_POINT',
-          user_point_id: '26340584-f777-404c-82c5-56220667464b'
-        } as core.UserPointIdentifierInfo,
-        {
-          type: 'USER_ACCOUNT',
-          user_account_id: '914eb2aa50cef7f3a8705b6bb54e50bb',
-          creation_ts: 1493118667529
-        } as core.UserAccountIdentifierInfo,
-        {
-          type: 'USER_EMAIL',
-          hash: 'e2749f6f4d8104ec385a75490b587c86',
-          email: undefined,
-          operator: undefined,
-          creation_ts: 1493118667529,
-          last_activity_ts: 1493127642622,
-          providers: []
-        } as core.UserEmailIdentifierInfo,
-        {
-          type: 'USER_AGENT',
-          vector_id: 'vec:886742516',
-          device: {
-            form_factor: 'PERSONAL_COMPUTER',
-            os_family: 'MAC_OS',
-            browser_family: 'CHROME',
-            brand: undefined,
-            model: undefined,
-            os_version: undefined,
-            carrier: undefined
-          },
-          creation_ts: 1493118667529,
-          last_activity_ts: 1493126966889,
-          providers: [],
-          mappings: []
-        } as core.UserAgentIdentifierInfo
-      ]
-    };
-
     request(runner.plugin.app)
       .post('/v1/external_segment_creation')
       .send(externalSegmentCreation)
@@ -243,9 +275,52 @@ describe.only('External Audience Feed API test', function () {
               .send(userSegmentUpdateRequest)
               .end(function (err, res) {
                 expect(res.status).to.equal(200);
-                expect(JSON.parse(res.text).data).to.deep.equal([{"destination_token":"destToken", "grouping_key":"segId","content":"my_string"}])
+                expect(JSON.parse(res.text).data).to.deep.equal([{ "destination_token": "destToken", "grouping_key": "segId", "content": "my_string" }])
                 expect(JSON.parse(res.text).status).to.be.eq('ok');
 
+                done();
+              });
+
+          });
+
+      });
+
+  });
+
+  it('Check that the plugin is returning 429 when sending status = "retry"', function (
+    done
+  ) {
+    const plugin = new MyFakeAudienceFeedConnector2(false);
+    runner = new core.TestingPluginRunner(plugin, rpMockup);
+    // We init the plugin
+    request(runner.plugin.app)
+      .post('/v1/init')
+      .send({ authentication_token: 'Manny', worker_id: 'Calavera' })
+      .end((err, res) => {
+        expect(res.status).to.equal(200);
+      });
+
+    request(runner.plugin.app)
+      .post('/v1/external_segment_creation')
+      .send(externalSegmentCreation)
+      .end(function (err, res) {
+        expect(res.status).to.equal(200);
+
+        expect(JSON.parse(res.text).status).to.be.eq('ok');
+
+        request(runner.plugin.app)
+          .post('/v1/external_segment_connection')
+          .send(externalSegmentConnection)
+          .end(function (err, res) {
+            expect(res.status).to.equal(200);
+
+            expect(JSON.parse(res.text).status).to.be.eq('ok');
+
+            request(runner.plugin.app)
+              .post('/v1/user_segment_update')
+              .send(userSegmentUpdateRequest)
+              .end(function (err, res) {
+                expect(res.status).to.equal(429);
                 done();
               });
 

--- a/src/tests/BasePluginTests.ts
+++ b/src/tests/BasePluginTests.ts
@@ -179,7 +179,7 @@ describe('Data File helper Tests', function () {
   const authenticationToken = 'Manny';
   const workerId = 'Calavera';
 
-  const fakeDataFile = new Buffer('Hello');
+  const fakeDataFile = Buffer.from('Hello');
 
   const rpMockup = sinon.stub().returns(Promise.resolve(fakeDataFile));
 


### PR DESCRIPTION
The idea behing this change is to return 429 errors code to deplay
message ingestion and to raise errors when batch are failing. Metrics
implementation to enable monitoring and alerting will be handle on
Engineering side

- Update interfaces
- Update code to be able to return a status name = "retry" which returns
a StatusCode = 429 while trying to push audiences to the external
partner (onUserSegmentUpdate method)
- Add a test to check it works
- Switch to new Buffer implementation