### PR TITLE
FIX: Refuse to process calls before the initialization

### DIFF
--- a/src/mediarithmics/plugins/activity-analyzer/ActivityAnalyzerBasePlugin.ts
+++ b/src/mediarithmics/plugins/activity-analyzer/ActivityAnalyzerBasePlugin.ts
@@ -96,7 +96,16 @@ export abstract class ActivityAnalyzerPlugin extends BasePlugin {
       '/v1/activity_analysis',
       this.asyncMiddleware(
         async (req: express.Request, res: express.Response) => {
-          if (!req.body || _.isEmpty(req.body)) {
+          if (!this.httpIsReady()) {
+            const msg = {
+              error: 'Plugin not initialized'
+            };
+            this.logger.error(
+              'POST /v1/activity_analysis : %s',
+              JSON.stringify(msg)
+            );
+            return res.status(500).json(msg);
+          } else if (!req.body || _.isEmpty(req.body)) {
             const msg = {
               error: 'Missing request body'
             };

--- a/src/mediarithmics/plugins/ad-renderer/base/AdRendererBasePlugin.ts
+++ b/src/mediarithmics/plugins/ad-renderer/base/AdRendererBasePlugin.ts
@@ -106,7 +106,16 @@ export abstract class AdRendererBasePlugin<T extends AdRendererBaseInstanceConte
       '/v1/ad_contents',
       this.asyncMiddleware(
         async (req: express.Request, res: express.Response) => {
-          if (!req.body || _.isEmpty(req.body)) {
+          if (!this.httpIsReady()) {
+            const msg = {
+              error: 'Plugin not initialized'
+            };
+            this.logger.error(
+              'POST /v1/ad_contents : %s',
+              JSON.stringify(msg)
+            );
+            return res.status(500).json(msg);
+          } else if (!req.body || _.isEmpty(req.body)) {
             const msg = {
               error: 'Missing request body'
             };

--- a/src/mediarithmics/plugins/audience-feed-connector/AudienceFeedConnectorBasePlugin.ts
+++ b/src/mediarithmics/plugins/audience-feed-connector/AudienceFeedConnectorBasePlugin.ts
@@ -135,6 +135,10 @@ export abstract class AudienceFeedConnectorBasePlugin extends BasePlugin {
             `POST /v1/external_segment_creation ${JSON.stringify(req.body)}`
           );
 
+          if (!this.httpIsReady()) {
+            throw new Error('Plugin not initialized');
+          }
+
           const request = req.body as ExternalSegmentCreationRequest;
 
           if (!this.onExternalSegmentCreation) {
@@ -182,6 +186,10 @@ export abstract class AudienceFeedConnectorBasePlugin extends BasePlugin {
           this.logger.debug(
             `POST /v1/external_segment_connection ${JSON.stringify(req.body)}`
           );
+
+          if (!this.httpIsReady()) {
+            throw new Error('Plugin not initialized');
+          }
 
           const request = req.body as ExternalSegmentConnectionRequest;
 

--- a/src/mediarithmics/plugins/bid-optimizer/BidOptimizerBasePlugin.ts
+++ b/src/mediarithmics/plugins/bid-optimizer/BidOptimizerBasePlugin.ts
@@ -142,7 +142,16 @@ export abstract class BidOptimizerPlugin extends BasePlugin {
       '/v1/bid_decisions',
       this.asyncMiddleware(
         async (req: express.Request, res: express.Response) => {
-          if (!req.body || _.isEmpty(req.body)) {
+          if (!this.httpIsReady()) {
+            const msg = {
+              error: 'Plugin not initialized'
+            };
+            this.logger.error(
+              'POST /v1/bid_decisions : %s',
+              JSON.stringify(msg)
+            );
+            return res.status(500).json(msg);
+          } else if (!req.body || _.isEmpty(req.body)) {
             const msg = {
               error: 'Missing request body'
             };

--- a/src/mediarithmics/plugins/common/BasePlugin.ts
+++ b/src/mediarithmics/plugins/common/BasePlugin.ts
@@ -386,6 +386,10 @@ export abstract class BasePlugin {
   start() {
   }
 
+  protected httpIsReady() {
+    return this.credentials && this.credentials.worker_id && this.credentials.authentication_token;
+  }
+
   // This method can be overridden by any subclass
   protected onLogLevelUpdateHandler(req: express.Request,
     res: express.Response) {
@@ -434,7 +438,7 @@ export abstract class BasePlugin {
   protected onStatusRequest(req: express.Request, res: express.Response) {
     //Route used by the plugin manager to check if the plugin is UP and running
     this.logger.silly('GET /v1/status');
-    if (this.credentials.worker_id && this.credentials.authentication_token) {
+    if (this.httpIsReady()) {
       res.status(200).end();
     } else {
       this.logger.error(

--- a/src/mediarithmics/plugins/email-renderer/base/EmailRendererBasePlugin.ts
+++ b/src/mediarithmics/plugins/email-renderer/base/EmailRendererBasePlugin.ts
@@ -86,7 +86,16 @@ export abstract class EmailRendererPlugin<T extends EmailRendererBaseInstanceCon
       '/v1/email_contents',
       this.asyncMiddleware(
         async (req: express.Request, res: express.Response) => {
-          if (!req.body || _.isEmpty(req.body)) {
+          if (!this.httpIsReady()) {
+            const msg = {
+              error: 'Plugin not initialized'
+            };
+            this.logger.error(
+              'POST /v1/email_contents : %s',
+              JSON.stringify(msg)
+            );
+            return res.status(500).json(msg);
+          } else if (!req.body || _.isEmpty(req.body)) {
             const msg = {
               error: 'Missing request body'
             };

--- a/src/mediarithmics/plugins/email-router/EmailRouterBasePlugin.ts
+++ b/src/mediarithmics/plugins/email-router/EmailRouterBasePlugin.ts
@@ -89,7 +89,16 @@ export abstract class EmailRouterPlugin extends BasePlugin {
       '/v1/email_routing',
       this.asyncMiddleware(
         async (req: express.Request, res: express.Response) => {
-          if (!req.body || _.isEmpty(req.body)) {
+          if (!this.httpIsReady()) {
+            const msg = {
+              error: 'Plugin not initialized'
+            };
+            this.logger.error(
+              'POST /v1/email_routing : %s',
+              JSON.stringify(msg)
+            );
+            return res.status(500).json(msg);
+          } else if (!req.body || _.isEmpty(req.body)) {
             const msg = {
               error: 'Missing request body'
             };
@@ -131,7 +140,16 @@ export abstract class EmailRouterPlugin extends BasePlugin {
     this.app.post(
       '/v1/email_router_check',
       (req: express.Request, res: express.Response) => {
-        if (!req.body || _.isEmpty(req.body)) {
+        if (!this.httpIsReady()) {
+            const msg = {
+              error: 'Plugin not initialized'
+            };
+            this.logger.error(
+              'POST /v1/email_router_check : %s',
+              JSON.stringify(msg)
+            );
+            return res.status(500).json(msg);
+          } else if (!req.body || _.isEmpty(req.body)) {
           const msg = {
             error: 'Missing request body'
           };

--- a/src/mediarithmics/plugins/recommender/RecommenderBasePlugin.ts
+++ b/src/mediarithmics/plugins/recommender/RecommenderBasePlugin.ts
@@ -95,7 +95,16 @@ export abstract class RecommenderPlugin extends BasePlugin {
       '/v1/recommendations',
       this.asyncMiddleware(
         async (req: express.Request, res: express.Response) => {
-          if (!req.body || _.isEmpty(req.body)) {
+          if (!this.httpIsReady()) {
+            const msg = {
+              error: 'Plugin not initialized'
+            };
+            this.logger.error(
+              'POST /v1/recommendations : %s',
+              JSON.stringify(msg)
+            );
+            return res.status(500).json(msg);
+          } else if (!req.body || _.isEmpty(req.body)) {
             const msg = {
               error: 'Missing request body'
             };

--- a/src/tests/ActivityAnalyzerTests.ts
+++ b/src/tests/ActivityAnalyzerTests.ts
@@ -189,9 +189,46 @@ describe('Activity Analysis API test', function () {
 
   });
 
+  it("Check that the plugin doesn't reply when not initialized", function (
+    done
+  ) {
+    const rpMockup = sinon.stub();
+
+    runner = new core.TestingPluginRunner(plugin, rpMockup);
+
+    // We init the plugin
+    request(runner.plugin.app)
+    const requestBody = JSON.parse(`{
+        "activity_analyzer_id": 123456789,
+        "datamart_id": 1034,
+        "channel_id": "1268",
+        "activity": {
+          "$email_hash": null,
+          "$events": [],
+          "$site_id": "1268",
+          "$ts": 1479820606901,
+          "$type": "SITE_VISIT"
+        }
+      }`);
+
+    request(runner.plugin.app)
+      .post('/v1/activity_analysis')
+      .send(requestBody)
+      .end(function (err, res) {
+        expect(res.status).to.equal(500);
+        expect(runner.plugin.pluginCache.size()).to.equal(0, "no cache should has been initialized when we don't even have init the plugin");
+
+        done();
+      });
+
+  });
+
+
   afterEach(() => {
     // We clear the cache so that we don't have any processing still running in the background
     runner.plugin.pluginCache.clear();
+    runner.plugin.credentials.worker_id = '';
+    runner.plugin.credentials.authentication_token = '';
   });
 
 });


### PR DESCRIPTION
With the lifecycle of the plugin, we should not get any request before
getting a `/v1/init` call and changing the health check response.
However, in some edge cases, we can get a race condition where a small
number of requests can still be sent. We don't have any credentials so
we can't prepare the context and can't properly handle the request.

However, if we don't stop ASAP the request we will save in the cache a
failed promise which will fail *all* requests for 10 minutes (for a
given instance id). Now, we still loose the extra early call(s) but
start processing correctly as soon as the initialization kicks in.