### PR TITLE
MICS-7419 Change CustomActionRequest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+# Next
+- Change CustomActionRequest for a custom action (instance_id to custom_action_id)
+
 # 0.7.13 - 2020-12-01
 
 - Add support for Custom Action plugins

--- a/examples/custom-action/src/tests/index.ts
+++ b/examples/custom-action/src/tests/index.ts
@@ -57,7 +57,7 @@ describe.only("Test Custom Action example", function () {
 
     const customActionRequest: core.CustomActionRequest = {
       user_point_id: "26340584-f777-404c-82c5-56220667464b",
-      instance_id: "62",
+      custom_action_id: "62",
     };
 
     request(runner.plugin.app)

--- a/src/mediarithmics/plugins/custom-action/CustomActionBasePlugin.ts
+++ b/src/mediarithmics/plugins/custom-action/CustomActionBasePlugin.ts
@@ -126,7 +126,7 @@ export abstract class CustomActionBasePlugin extends BasePlugin {
           }
 
           const instanceContext = await this.getInstanceContext(
-            request.instance_id
+            request.custom_action_id
           );
 
           const response = await this.onCustomActionCall(
@@ -135,7 +135,7 @@ export abstract class CustomActionBasePlugin extends BasePlugin {
           );
 
           this.logger.debug(
-            `CustomActionId: ${request.instance_id} - Plugin impl returned: %j`,
+            `CustomActionId: ${request.custom_action_id} - Plugin impl returned: %j`,
             response
           );
 
@@ -157,7 +157,7 @@ export abstract class CustomActionBasePlugin extends BasePlugin {
           }
 
           this.logger.debug(
-            `CustomActionId: ${request.instance_id} - Returning : ${statusCode} - %j`,
+            `CustomActionId: ${request.custom_action_id} - Returning : ${statusCode} - %j`,
             response
           );
 

--- a/src/mediarithmics/plugins/custom-action/CustomActionInterface.ts
+++ b/src/mediarithmics/plugins/custom-action/CustomActionInterface.ts
@@ -1,6 +1,6 @@
 export interface CustomActionRequest {
   user_point_id: string;
-  instance_id: string; // custom action id, used to fetch the instance context, aka the instance configuration
+  custom_action_id: string;
 }
 
 export interface CustomActionPluginResponse {

--- a/src/tests/CustomActionBaseTest.ts
+++ b/src/tests/CustomActionBaseTest.ts
@@ -27,7 +27,7 @@ describe("Fetch Scenario Custom Action Gateway API", () => {
   const plugin = new MyFakeCustomActionBasePlugin(false);
   const runner = new core.TestingPluginRunner(plugin, rpMockup);
 
-  it("Check that instance_id is passed correctly in fetchCustomActionProperties", function (done) {
+  it("Check that custom_action_id is passed correctly in fetchCustomActionProperties", function (done) {
     const fakeId = "62";
 
     // We try to call the Gateway
@@ -41,7 +41,7 @@ describe("Fetch Scenario Custom Action Gateway API", () => {
       });
   });
 
-  it("Check that instance_id is passed correctly in fetchCustomAction", function (done) {
+  it("Check that custom_action_id is passed correctly in fetchCustomAction", function (done) {
     const fakeId = "62";
 
     // We try to call the Gateway
@@ -113,7 +113,7 @@ describe.only("Custom Action API test", function () {
 
     const customActionRequest: core.CustomActionRequest = {
       user_point_id: "26340584-f777-404c-82c5-56220667464b",
-      instance_id: "62",
+      custom_action_id: "62",
     };
 
     request(runner.plugin.app)


### PR DESCRIPTION
instance_id is replaced by custom_action_id in CustomActionRequest,
in order to have a more meaningful name.