### PR TITLE
Migrate to the new way to get credentials

### DIFF
--- a/examples/activity-analyzer/src/tests/index.ts
+++ b/examples/activity-analyzer/src/tests/index.ts
@@ -2,6 +2,13 @@ import 'mocha';
 import {core, helpers} from '@mediarithmics/plugins-nodejs-sdk';
 import {MyActivityAnalyzerPlugin} from '../MyPluginImpl';
 
+const PLUGIN_AUTHENTICATION_TOKEN = 'Manny';
+const PLUGIN_WORKER_ID = 'Calavera';
+
+// set by the plugin runner in production
+process.env.PLUGIN_AUTHENTICATION_TOKEN = PLUGIN_AUTHENTICATION_TOKEN;
+process.env.PLUGIN_WORKER_ID = PLUGIN_WORKER_ID;
+
 describe("Test Example Activity Analyzer", function () {
 
     const activityAnalyzerProperties: core.PluginPropertyResponse = {

--- a/examples/custom-action/src/tests/index.ts
+++ b/examples/custom-action/src/tests/index.ts
@@ -13,6 +13,36 @@ describe.only("Test Custom Action example", function () {
   it("Check the behavior of a dummy custom action", function (done) {
     const rpMockup: sinon.SinonStub = sinon.stub();
 
+    const customAction: core.DataResponse<core.CustomAction> = {
+      status: 'ok',
+      data: {
+        id: "1",
+        name: "custom action",
+        organisation_id: "1234",
+        group_id: "com.test.custom-action",
+        artifact_id: "test",
+        creation_ts: 1234,
+        created_by: "2",
+        version_id: "3",
+        version_value: "1.0.0"
+      }
+    };
+    rpMockup
+      .withArgs(
+        sinon.match.has(
+          "uri",
+          sinon.match(function (value: string) {
+            return (
+              value.match(
+                /\/v1\/scenario_custom_actions\/(.){1,10}$/
+              ) !== null
+            );
+          })
+        )
+      )
+      .returns(customAction);
+
+
     const properties: core.DataListResponse<core.PluginProperty> = {
       status: "ok",
       count: 1,

--- a/examples/custom-action/src/tests/index.ts
+++ b/examples/custom-action/src/tests/index.ts
@@ -5,6 +5,13 @@ import * as request from "supertest";
 import * as sinon from "sinon";
 import { MyCustomActionPlugin } from "../MyPluginImpl";
 
+const PLUGIN_AUTHENTICATION_TOKEN = 'Manny';
+const PLUGIN_WORKER_ID = 'Calavera';
+
+// set by the plugin runner in production
+process.env.PLUGIN_AUTHENTICATION_TOKEN = PLUGIN_AUTHENTICATION_TOKEN;
+process.env.PLUGIN_WORKER_ID = PLUGIN_WORKER_ID;
+
 describe.only("Test Custom Action example", function () {
   // All the magic is here
   const plugin = new MyCustomActionPlugin(false);
@@ -76,14 +83,6 @@ describe.only("Test Custom Action example", function () {
       .returns(properties);
 
     runner = new core.TestingPluginRunner(plugin, rpMockup);
-
-    // We init the plugin
-    request(runner.plugin.app)
-      .post("/v1/init")
-      .send({ authentication_token: "Manny", worker_id: "Calavera" })
-      .end((err, res) => {
-        expect(res.status).to.equal(200);
-      });
 
     const customActionRequest: core.CustomActionRequest = {
       user_point_id: "26340584-f777-404c-82c5-56220667464b",

--- a/examples/email-renderer/src/tests/index.ts
+++ b/examples/email-renderer/src/tests/index.ts
@@ -5,6 +5,13 @@ import * as request from "supertest";
 import * as sinon from "sinon";
 import { ExampleEmailRenderer } from "../ExampleEmailRenderer";
 
+const PLUGIN_AUTHENTICATION_TOKEN = 'Manny';
+const PLUGIN_WORKER_ID = 'Calavera';
+
+// set by the plugin runner in production
+process.env.PLUGIN_AUTHENTICATION_TOKEN = PLUGIN_AUTHENTICATION_TOKEN;
+process.env.PLUGIN_WORKER_ID = PLUGIN_WORKER_ID;
+
 describe.only("Test Email Renderer example", function () {
   const plugin = new ExampleEmailRenderer(false);
   let runner: core.TestingPluginRunner;
@@ -55,14 +62,6 @@ describe.only("Test Email Renderer example", function () {
         .returns(properties);
 
     runner = new core.TestingPluginRunner(plugin, rpMockup);
-
-    // We init the plugin
-    request(runner.plugin.app)
-        .post("/v1/init")
-        .send({ authentication_token: "Manny", worker_id: "Calavera" })
-        .end((err, res) => {
-          expect(res.status).to.equal(200);
-        });
 
     const emailRenderRequest: core.EmailRenderRequest = {
       email_renderer_id: "54",

--- a/examples/email_router/src/tests/index.ts
+++ b/examples/email_router/src/tests/index.ts
@@ -5,6 +5,13 @@ import * as request from 'supertest';
 import * as sinon from 'sinon';
 import {MailjetSentResponse, MySimpleEmailRouter} from '../MyPluginImpl';
 
+const PLUGIN_AUTHENTICATION_TOKEN = 'Manny';
+const PLUGIN_WORKER_ID = 'Calavera';
+
+// set by the plugin runner in production
+process.env.PLUGIN_AUTHENTICATION_TOKEN = PLUGIN_AUTHENTICATION_TOKEN;
+process.env.PLUGIN_WORKER_ID = PLUGIN_WORKER_ID;
+
 describe('Test Example Email Router', function () {
 
   function buildRpMockup() {
@@ -137,33 +144,25 @@ describe('Test Example Email Router', function () {
       )
       .returns(mjResponse);
 
-    // Plugin init
+    // Plugin log level to debug
     request(runner.plugin.app)
-      .post('/v1/init')
-      .send({authentication_token: 'Manny', worker_id: 'Calavera'})
+      .put('/v1/log_level')
+      .send({level: 'debug'})
       .end((err, res) => {
         expect(res.status).to.equal(200);
 
-        // Plugin log level to debug
+        // Activity to process
         request(runner.plugin.app)
-          .put('/v1/log_level')
-          .send({level: 'debug'})
+          .post('/v1/email_routing')
+          .send(emailRoutingRequest)
           .end((err, res) => {
-            expect(res.status).to.equal(200);
+            expect(res.status).to.eq(200);
 
-            // Activity to process
-            request(runner.plugin.app)
-              .post('/v1/email_routing')
-              .send(emailRoutingRequest)
-              .end((err, res) => {
-                expect(res.status).to.eq(200);
-
-                expect(
-                  (JSON.parse(res.text) as core.EmailRoutingPluginResponse)
-                    .result
-                ).to.be.true;
-                done();
-              });
+            expect(
+              (JSON.parse(res.text) as core.EmailRoutingPluginResponse)
+              .result
+            ).to.be.true;
+            done();
           });
       });
   });
@@ -265,33 +264,25 @@ describe('Test Example Email Router', function () {
     });
     mjMock.onCall(3).returns(mjResponse);
 
-    // Plugin init
+    // Plugin log level to debug
     request(runner.plugin.app)
-      .post('/v1/init')
-      .send({authentication_token: 'Manny', worker_id: 'Calavera'})
+      .put('/v1/log_level')
+      .send({level: 'debug'})
       .end((err, res) => {
         expect(res.status).to.equal(200);
 
-        // Plugin log level to debug
+        // Activity to process
         request(runner.plugin.app)
-          .put('/v1/log_level')
-          .send({level: 'debug'})
+          .post('/v1/email_routing')
+          .send(emailRoutingRequest)
           .end((err, res) => {
-            expect(res.status).to.equal(200);
+            expect(res.status).to.eq(200);
 
-            // Activity to process
-            request(runner.plugin.app)
-              .post('/v1/email_routing')
-              .send(emailRoutingRequest)
-              .end((err, res) => {
-                expect(res.status).to.eq(200);
-
-                expect(
-                  (JSON.parse(res.text) as core.EmailRoutingPluginResponse)
-                    .result
-                ).to.be.true;
-                done();
-              });
+            expect(
+              (JSON.parse(res.text) as core.EmailRoutingPluginResponse)
+              .result
+            ).to.be.true;
+            done();
           });
       });
   });

--- a/examples/simple-ad-renderer/test.sh
+++ b/examples/simple-ad-renderer/test.sh
@@ -9,12 +9,14 @@ gateway_pid=$!
 
 sleep 1
 
+export PLUGIN_AUTHENTICATION_TOKEN='123'
+export PLUGIN_WORKER_ID='123'
+
 node build/index.js &
 plugin_pid=$!
 
 sleep 1
 
-curl -X POST -H "Content-Type: application/json" -d '{"authentication_token":"123", "worker_id":"123"}' http://${PLUGIN_HOST}:${PLUGIN_PORT}/v1/init
 curl -X PUT -H "Content-Type: application/json" -d '{"level":"debug"}' http://${PLUGIN_HOST}:${PLUGIN_PORT}/v1/log_level
 curl -v -X POST http://${PLUGIN_HOST}:${PLUGIN_PORT}/v1/ad_contents  -d '
     {

--- a/src/helpers/ActivityAnalyzerTestHelper.ts
+++ b/src/helpers/ActivityAnalyzerTestHelper.ts
@@ -39,25 +39,18 @@ const itFactory = (
     const runner = new core.TestingPluginRunner(plugin, rpMockupGlobal);
 
     request(runner.plugin.app)
-      .post('/v1/init')
-      .send({authentication_token: 'Manny', worker_id: 'Calavera'})
+      .put('/v1/log_level')
+      .send({level: logLevel})
       .end((err, res) => {
         expect(res.status).to.equal(200);
 
         request(runner.plugin.app)
-          .put('/v1/log_level')
-          .send({level: logLevel})
+          .post('/v1/activity_analysis')
+          .send(input)
           .end((err, res) => {
-            expect(res.status).to.equal(200);
-
-            request(runner.plugin.app)
-              .post('/v1/activity_analysis')
-              .send(input)
-              .end((err, res) => {
-                expect(res.status).to.eq(200);
-                expect(JSON.parse(res.text)).to.be.deep.equal(output);
-                done();
-              });
+            expect(res.status).to.eq(200);
+            expect(JSON.parse(res.text)).to.be.deep.equal(output);
+            done();
           });
       });
 

--- a/src/tests/AdRendererRecoTests.ts
+++ b/src/tests/AdRendererRecoTests.ts
@@ -4,6 +4,13 @@ import {core, extra} from '../';
 import * as sinon from 'sinon';
 import {PropertiesWrapper} from '../mediarithmics/index';
 
+const PLUGIN_AUTHENTICATION_TOKEN = 'Manny';
+const PLUGIN_WORKER_ID = 'Calavera';
+
+// set by the plugin runner in production
+process.env.PLUGIN_AUTHENTICATION_TOKEN = PLUGIN_AUTHENTICATION_TOKEN;
+process.env.PLUGIN_WORKER_ID = PLUGIN_WORKER_ID;
+
 describe('Fetch recommendation API', () => {
   class MyDummyHandlebarsAdRenderer extends core.AdRendererRecoTemplatePlugin {
     engineBuilder = new extra.HandlebarsEngine();

--- a/src/tests/AudienceFeedConnector.ts
+++ b/src/tests/AudienceFeedConnector.ts
@@ -4,6 +4,13 @@ import {core} from '../';
 import * as request from 'supertest';
 import * as sinon from 'sinon';
 
+const PLUGIN_AUTHENTICATION_TOKEN = 'Manny';
+const PLUGIN_WORKER_ID = 'Calavera';
+
+// set by the plugin runner in production
+process.env.PLUGIN_AUTHENTICATION_TOKEN = PLUGIN_AUTHENTICATION_TOKEN;
+process.env.PLUGIN_WORKER_ID = PLUGIN_WORKER_ID;
+
 class MyFakeAudienceFeedConnector extends core.AudienceFeedConnectorBasePlugin {
   protected onExternalSegmentCreation(
     request: core.ExternalSegmentCreationRequest,
@@ -155,14 +162,6 @@ describe.only('External Audience Feed API test', function () {
       .returns(properties);
 
     runner = new core.TestingPluginRunner(plugin, rpMockup);
-
-    // We init the plugin
-    request(runner.plugin.app)
-      .post('/v1/init')
-      .send({authentication_token: 'Manny', worker_id: 'Calavera'})
-      .end((err, res) => {
-        expect(res.status).to.equal(200);
-      });
 
     const externalSegmentCreation: core.ExternalSegmentCreationRequest = {
       feed_id: '42',

--- a/src/tests/CustomActionBaseTest.ts
+++ b/src/tests/CustomActionBaseTest.ts
@@ -6,6 +6,13 @@ import * as sinon from "sinon";
 import { CustomActionBaseInstanceContext } from "../mediarithmics/plugins/custom-action/CustomActionBasePlugin";
 import { PropertiesWrapper } from "../mediarithmics";
 
+const PLUGIN_AUTHENTICATION_TOKEN = 'Manny';
+const PLUGIN_WORKER_ID = 'Calavera';
+
+// set by the plugin runner in production
+process.env.PLUGIN_AUTHENTICATION_TOKEN = PLUGIN_AUTHENTICATION_TOKEN;
+process.env.PLUGIN_WORKER_ID = PLUGIN_WORKER_ID;
+
 class MyFakeCustomActionBasePlugin extends core.CustomActionBasePlugin {
   protected async instanceContextBuilder(
     customActionId: string
@@ -152,14 +159,6 @@ describe.only("Custom Action API test", function () {
       .returns(properties);
 
     runner = new core.TestingPluginRunner(plugin, rpMockup);
-
-    // We init the plugin
-    request(runner.plugin.app)
-      .post("/v1/init")
-      .send({ authentication_token: "Manny", worker_id: "Calavera" })
-      .end((err, res) => {
-        expect(res.status).to.equal(200);
-      });
 
     const customActionRequest: core.CustomActionRequest = {
       user_point_id: "26340584-f777-404c-82c5-56220667464b",

--- a/src/tests/EmailRendererTests.ts
+++ b/src/tests/EmailRendererTests.ts
@@ -4,6 +4,13 @@ import {core} from '../';
 import * as request from 'supertest';
 import * as sinon from 'sinon';
 
+const PLUGIN_AUTHENTICATION_TOKEN = 'Manny';
+const PLUGIN_WORKER_ID = 'Calavera';
+
+// set by the plugin runner in production
+process.env.PLUGIN_AUTHENTICATION_TOKEN = PLUGIN_AUTHENTICATION_TOKEN;
+process.env.PLUGIN_WORKER_ID = PLUGIN_WORKER_ID;
+
 class MyFakeEmailRendererPlugin extends core.EmailRendererPlugin {
   protected onEmailContents(
     request: core.EmailRenderRequest,
@@ -127,14 +134,7 @@ describe('Email Renderer API test', function () {
 
     runner = new core.TestingPluginRunner(plugin, rpMockup);
 
-    // We init the plugin
-    request(runner.plugin.app)
-      .post('/v1/init')
-      .send({authentication_token: 'Manny', worker_id: 'Calavera'})
-      .end((err, res) => {
-        expect(res.status).to.equal(200);
-
-        const requestBody = JSON.parse(`{
+    const requestBody = JSON.parse(`{
           "email_renderer_id": "1034",
           "call_id": "8e20e0fc-acb5-4bf3-8e36-f85a9ff25150",
           "context": "LIVE",
@@ -164,17 +164,15 @@ describe('Email Renderer API test', function () {
           "email_tracking_url": null
         }`);
 
-        request(runner.plugin.app)
-          .post('/v1/email_contents')
-          .send(requestBody)
-          .end(function (err, res) {
-            expect(res.status).to.equal(200);
+    request(runner.plugin.app)
+      .post('/v1/email_contents')
+      .send(requestBody)
+      .end(function (err, res) {
+        expect(res.status).to.equal(200);
 
-            expect(JSON.parse(res.text).content.html).to.be.eq(requestBody.call_id);
+        expect(JSON.parse(res.text).content.html).to.be.eq(requestBody.call_id);
 
-            done();
-          });
-
+        done();
       });
 
   });

--- a/src/tests/EmailRouterTests.ts
+++ b/src/tests/EmailRouterTests.ts
@@ -4,6 +4,13 @@ import {core} from '../';
 import * as request from 'supertest';
 import * as sinon from 'sinon';
 
+const PLUGIN_AUTHENTICATION_TOKEN = 'Manny';
+const PLUGIN_WORKER_ID = 'Calavera';
+
+// set by the plugin runner in production
+process.env.PLUGIN_AUTHENTICATION_TOKEN = PLUGIN_AUTHENTICATION_TOKEN;
+process.env.PLUGIN_WORKER_ID = PLUGIN_WORKER_ID;
+
 class MyFakeEmailRouterPlugin extends core.EmailRouterPlugin {
   protected onEmailRouting(
     request: core.EmailRoutingRequest,
@@ -93,14 +100,6 @@ describe('Email Router API test', function () {
     );
 
     runner = new core.TestingPluginRunner(plugin, rpMockup);
-
-    // We init the plugin
-    request(runner.plugin.app)
-      .post('/v1/init')
-      .send({authentication_token: 'Manny', worker_id: 'Calavera'})
-      .end((err, res) => {
-        expect(res.status).to.equal(200);
-      });
 
     const requestBody = JSON.parse(`{
       "email_router_id": "2",

--- a/src/tests/RecommenderTests.ts
+++ b/src/tests/RecommenderTests.ts
@@ -4,6 +4,13 @@ import {core} from '../';
 import * as request from 'supertest';
 import * as sinon from 'sinon';
 
+const PLUGIN_AUTHENTICATION_TOKEN = 'Manny';
+const PLUGIN_WORKER_ID = 'Calavera';
+
+// set by the plugin runner in production
+process.env.PLUGIN_AUTHENTICATION_TOKEN = PLUGIN_AUTHENTICATION_TOKEN;
+process.env.PLUGIN_WORKER_ID = PLUGIN_WORKER_ID;
+
 describe('Fetch recommender API', () => {
   class MyFakeRecommenderPlugin extends core.RecommenderPlugin {
     protected onRecommendationRequest(
@@ -122,14 +129,6 @@ describe('Recommender API test', function () {
       .returns(fakeRecommenderProperties);
 
     runner = new core.TestingPluginRunner(plugin, rpMockup);
-
-    // We init the plugin
-    request(runner.plugin.app)
-      .post('/v1/init')
-      .send({authentication_token: 'Manny', worker_id: 'Calavera'})
-      .end((err, res) => {
-        expect(res.status).to.equal(200);
-      });
 
     const requestBody = {
       recommender_id: '5',

--- a/testOnly.sh
+++ b/testOnly.sh
@@ -3,7 +3,7 @@ set -eu
 
 
 function doTest(){
-    mocha -r ts-node/register src/tests/$1
+    ./node_modules/.bin/mocha -r ts-node/register src/tests/$1
 }
 
 if [ "$#" -gt 0 ]

--- a/test_sdk_and_examples.sh
+++ b/test_sdk_and_examples.sh
@@ -7,18 +7,19 @@ npm run prepublishOnly
 
 export TS_NODE_TYPE_CHECK=1
 for t in src/tests/*.ts; do
+  echo "Testing $t..."
   mocha -r ts-node/register $t
 done
 
 npm link
 
 for ex in examples/*; do
+    echo "Testing $ex..."
     cd $ex
     if [ -f ./package.json ]; then
         rm -rf node_modules
-        npm link @mediarithmics/plugins-nodejs-sdk
         npm i --no-package-lock
-        #npm link @mediarithmics/plugins-nodejs-sdk #yes twice, needed for install but install remove link >_<
+        npm link @mediarithmics/plugins-nodejs-sdk
         npm run test
     fi
     cd -


### PR DESCRIPTION
The platform now gives credentials (worker_id/authentication_token) via
the environment. The `CREDENTIAL_UPDATE_FROM_*` mechanism can also be
removed as all processes will get the same env / the same credentials,
and they don't change anymore (for the lifetime of the container).
While not perfect, overriding the env in the tests code avoid a
dependency to a wrapper script.
This is a breaking change: the api changes, all tests must be fixed.