### PR TITLE
Remove examples from the bundled npm archive

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,3 @@
 .vscode/
 .idea/
+examples/


### PR DESCRIPTION
The examples/ folder can contain a lot of node_modules/ which are not
automatically excluded. The release 0.9.0 weights 500MB instead of the
usual ~500KB because of that. Examples are not needed to run the lib, we
can ignore them.