### PR TITLE
MICS-12762 Move test helper dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,11 @@
 		"request": "^2.88.0",
 		"request-promise-native": "^1.0.8",
 		"toobusy-js": "^0.5.1",
-		"winston": "^3.2.1"
+		"winston": "^3.2.1",
+		"chai": "^4.2.0",
+		"mocha": "^6.2.2",
+		"supertest": "^4.0.2",
+		"sinon": "^7.5.0"
 	},
 	"devDependencies": {
 		"@types/chai": "^4.2.5",
@@ -45,12 +49,8 @@
 		"@types/numeral": "0.0.26",
 		"@types/sinon": "^7.5.1",
 		"@types/supertest": "^2.0.8",
-		"chai": "^4.2.0",
-		"mocha": "^6.2.2",
 		"mockery": "^2.1.0",
 		"proxyquire": "^2.1.3",
-		"sinon": "^7.5.0",
-		"supertest": "^4.0.2",
 		"ts-node": "^8.5.4",
 		"typedoc": "^0.15.3",
 		"typescript": "^3.7.3"


### PR DESCRIPTION
The test dependencies had to be moved from 'devDependencies' to prod
dependencies because of the exported test helper 'itFactory'.