### PR TITLE
Fix stat clients in tests

### DIFF
--- a/src/helpers/StatsClient.ts
+++ b/src/helpers/StatsClient.ts
@@ -53,7 +53,7 @@ export class StatsClient {
 		this.metrics = new Map();
 		this.logger = logger;
 		this.client = new StatsD({
-			protocol: 'uds',
+			protocol: process.env.NODE_ENV === 'production' ? 'uds' : undefined,
 		});
 
 		if (!this.interval) {


### PR DESCRIPTION
The `uds` procotol expects a working socket on
`/var/run/datadog/dsd.socket`.

We don't have it during tests and got:

> Error: Socket not created properly. Check previous errors for details.
> Error: connect -2

Outside production we now default to udp on localhost, which does not
fail.