### PR TITLE
MICS-14615 SyncResult modification

### DIFF
--- a/src/mediarithmics/api/plugin/audiencefeedconnector/AudienceFeedConnectorPluginResponseInterface.ts
+++ b/src/mediarithmics/api/plugin/audiencefeedconnector/AudienceFeedConnectorPluginResponseInterface.ts
@@ -19,8 +19,13 @@ export interface ExternalSegmentConnectionPluginResponse {
   message?: string;
 }
 
+export type UserSegmentUpdatePluginResponseStatus = 
+  | AudienceFeedConnectorStatus
+  | 'retry'
+  | 'no_eligible_identifier';
+
 export interface UserSegmentUpdatePluginResponse {
-  status: AudienceFeedConnectorStatus | 'retry';
+  status: UserSegmentUpdatePluginResponseStatus;
   data?: UserSegmentUpdatePluginResponseData[];
   stats?: UserSegmentUpdatePluginResponseStats[];
   message?: string;
@@ -36,12 +41,16 @@ export interface UserSegmentUpdatePluginResponseData {
 
 type SyncResult =
   | 'PROCESSED'
-  | 'FAILURE'
-  | 'NO_ELIGIBLE_IDENTIFIER'
-  | 'SUCCESS';
+  | 'SUCCESS'
+  | 'REJECTED';
 
 export interface UserSegmentUpdatePluginResponseStats {
-  identifier?: string;
-  sync_result?: SyncResult;
-  tags?: { key: string; value: string };
+  identifier: string;
+  sync_result: SyncResult;
+  tags?: AudienceFeedStatTag[];
+}
+
+export interface AudienceFeedStatTag {
+  key: string;
+  value: string;
 }

--- a/src/mediarithmics/plugins/audience-feed-connector/AudienceFeedConnectorBasePlugin.ts
+++ b/src/mediarithmics/plugins/audience-feed-connector/AudienceFeedConnectorBasePlugin.ts
@@ -343,6 +343,9 @@ export abstract class AudienceFeedConnectorBasePlugin extends BasePlugin<Audienc
             case 'retry':
               statusCode = 429;
               break;
+            case 'no_eligible_identifier':
+              statusCode = 400;
+              break;
             default:
               statusCode = 500;
           }


### PR DESCRIPTION
This commit renders sync_result mandatory in
UserSegmentUpdatePluginResponseStats.
It also adds a possible value for SyncResult which is IDENTIFIER_REJECTED.