### PR TITLE
MICS-15536 Rework AudienceFeedConnectorBasePlugin hierarchy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+# 0.14.0 - XXXX-XX-XX
+
+- New subclasses for `AudienceFeedConnectorBasePlugin` and `BatchedAudienceFeedConnectorBasePlugin<T>`, related to batched content.
+- Breaking changes in `UserSegmentUpdatePluginResponse`, when used with `UserSegmentUpdatePluginBatchDeliveryResponseData`.
+  - To output `BATCH_DELIVERY`, implement `BatchedAudienceFeedConnectorBasePlugin` instead, that will force implementation of 
+  ```    
+  protected abstract onUserSegmentUpdate(request: UserSegmentUpdateRequest, instanceContext: AudienceFeedConnectorBaseInstanceContext): Promise<BatchedUserSegmentUpdatePluginResponse<T>>;
+  ```
+- Force not null content in `UserSegmentUpdatePluginDeliveryContent`
+  - Don't output `UserSegmentUpdatePluginDeliveryContent` if content is empty.
+- Update `BatchUpdatePluginResponse#status` to uppercase status, instead of lowercase.
+
+
 # 0.13.0 - 2023-03-27
 
 Breaking changes in UserSegmentUpdatePluginResponse:

--- a/src/mediarithmics/api/core/batchupdate/BatchUpdateHandler.ts
+++ b/src/mediarithmics/api/core/batchupdate/BatchUpdateHandler.ts
@@ -1,0 +1,73 @@
+
+import express from 'express';
+import winston from 'winston';
+import { BatchUpdateContext, BatchUpdatePluginResponse, BatchUpdateRequest } from './BatchUpdateInterface';
+
+export type CallOnBatchUpdate<C extends BatchUpdateContext, T> = (request: BatchUpdateRequest<C, T>) => Promise<BatchUpdatePluginResponse>
+export type DeserializerT<T> = (obj: string) => T
+export class BatchUpdateHandler<C extends BatchUpdateContext, T> {
+
+
+    logger: winston.Logger;
+    app: express.Application;
+    emptyBodyFilter: (req: express.Request, res: express.Response, next: express.NextFunction) => void;
+    
+    constructor(
+        app: express.Application,
+        emptyBodyFilter: (req: express.Request, res: express.Response, next: express.NextFunction) => void,
+        logger: winston.Logger) {
+        this.app = app;
+        this.emptyBodyFilter = emptyBodyFilter;
+        this.logger = logger;
+
+    }
+
+    public registerRoute(onbatchUpdateFn: CallOnBatchUpdate<C, T>): void {
+        this.app.post('/v1/batch_update', this.emptyBodyFilter, async (req: express.Request, res: express.Response) => {
+            try {
+                this.logger.debug(`POST /v1/batch_update ${JSON.stringify(req.body)}`);
+
+                const request = req.body as BatchUpdateRequest<C, T>;
+
+                const response: BatchUpdatePluginResponse = await onbatchUpdateFn(request);
+
+                this.logger.debug(`Returning: ${JSON.stringify(response)}`);
+
+                const pluginResponse: BatchUpdatePluginResponse = {
+                    status: response.status,
+                };
+
+                if (response.next_msg_delay_in_ms) {
+                    res.set('x-mics-next-msg-delay', response.next_msg_delay_in_ms.toString());
+                }
+
+                if (response.message) {
+                    pluginResponse.message = response.message;
+                }
+
+                let statusCode: number;
+                switch (response.status) {
+                    case 'OK':
+                        statusCode = 200;
+                        break;
+                    case 'ERROR':
+                        statusCode = 400;
+                        break;
+                    case 'RETRY':
+                        statusCode = 503;
+                        break;
+                    default:
+                        statusCode = 500;
+                }
+
+                return res.status(statusCode).send(JSON.stringify(pluginResponse));
+            } catch (err) {
+                this.logger.error(
+                    `Something bad happened : ${(err as Error).message} - ${(err as Error).stack ? ((err as Error).stack as string) : 'stack undefined'
+                    }`,
+                );
+                return res.status(500).send({ status: 'error', message: `${(err as Error).message}` });
+            }
+        })
+    }
+}

--- a/src/mediarithmics/api/core/batchupdate/BatchUpdateInterface.ts
+++ b/src/mediarithmics/api/core/batchupdate/BatchUpdateInterface.ts
@@ -1,0 +1,18 @@
+
+export interface BatchUpdateContext {
+    endpoint: string;
+    grouping_key: string;
+}
+
+export interface BatchUpdateRequest<C extends BatchUpdateContext, T> {
+    batch_content: T[];
+    ts: number;
+    context: C;
+}
+export interface BatchUpdatePluginResponse {
+    status: BatchUpdatePluginResponseStatus;
+    message?: string;
+    next_msg_delay_in_ms?: number;
+}
+
+export type BatchUpdatePluginResponseStatus = 'OK' | 'ERROR' | 'RETRY';

--- a/src/mediarithmics/api/plugin/audiencefeedconnector/AudienceFeedConnectorPluginResponseInterface.ts
+++ b/src/mediarithmics/api/plugin/audiencefeedconnector/AudienceFeedConnectorPluginResponseInterface.ts
@@ -1,10 +1,20 @@
-export type AudienceFeedConnectorStatus = 'ok' | 'error';
+import { StatusCode } from "../../core/common/Response";
+
+export type AudienceFeedConnectorStatus = 'ok' | 'error' | 'retry' | 'no_eligible_identifier';
 export declare type AudienceFeedConnectorConnectionStatus = 'ok' | 'error' | 'external_segment_not_ready_yet';
 export type AudienceFeedConnectorContentType = 'text/csv' | 'application/json' | 'text/plain';
 
 export interface UserSegmentUpdatePluginResponse {
-  status: DeliveredDataPluginResponseStatus;
-  data?: DeliveryType<unknown>[];
+  status: AudienceFeedConnectorStatus;
+  data?: UserSegmentUpdatePluginFileDeliveryResponseData[];
+  stats?: UserSegmentUpdatePluginResponseStats[];
+  message?: string;
+  next_msg_delay_in_ms?: number;
+}
+
+export interface BatchedUserSegmentUpdatePluginResponse<T> {
+  status: AudienceFeedConnectorStatus;
+  data?: UserSegmentUpdatePluginBatchDeliveryResponseData<T>[];
   stats?: UserSegmentUpdatePluginResponseStats[];
   message?: string;
   next_msg_delay_in_ms?: number;
@@ -25,7 +35,7 @@ export interface UserSegmentUpdatePluginBatchDeliveryResponseData<T> extends Use
 }
 
 export interface UserSegmentUpdatePluginDeliveryContent<T> {
-  content?: T;
+  content: T;
   grouping_key: string;
 }
 
@@ -53,10 +63,4 @@ export interface AudienceFeedStatTag {
   value: string;
 }
 
-export interface BatchUpdatePluginResponse {
-  status: DeliveredDataPluginResponseStatus;
-  message?: string;
-  next_msg_delay_in_ms?: number;
-}
 
-export type DeliveredDataPluginResponseStatus = AudienceFeedConnectorStatus | 'retry' | 'no_eligible_identifier';

--- a/src/mediarithmics/api/plugin/audiencefeedconnector/AudienceFeedConnectorRequestInterface.ts
+++ b/src/mediarithmics/api/plugin/audiencefeedconnector/AudienceFeedConnectorRequestInterface.ts
@@ -1,3 +1,4 @@
+import { BatchUpdateContext } from '../../core/batchupdate/BatchUpdateInterface';
 import { UserIdentifierInfo } from '../../reference/UserIdentifierInterface';
 
 export type UpdateType = 'UPSERT' | 'DELETE';
@@ -24,13 +25,8 @@ export interface ExternalSegmentCreationRequest {
   segment_id: string;
 }
 
-export interface BatchUpdateRequest<T> {
-  batch_content: T[];
-  ts: number;
-  context: AudienceFeedBatchContext;
-}
 
-export interface AudienceFeedBatchContext {
+export interface AudienceFeedBatchContext extends BatchUpdateContext {
   endpoint: string;
   feed_id: string;
   feed_session_id: string;


### PR DESCRIPTION
To simplify downstream API, this commit adds 2 new abstract classes to isolate plugin with or without batching feature.

Thanks to this, it's easy to see in implementation if plugin implements `AudienceFeedConnectorBasePlugin` or
`BatchedAudienceFeedConnectorBasePlugin<T>`.
When using batch, it also :
 - explicits the type of the line, and of the batch context.
 - require implementation to provide ser/deserialization methods to string.
 - require implementation of the onBatchUpdate.

With the vanilla implementation, the implementation cannot respond with `UserSegmentUpdatePluginBatchDeliveryResponseData`, and cannot override onBatchUpdate.