### PR TITLE
MICS-16538 Repair Datadog metrics

### DIFF
--- a/src/helpers/StatsClient.spec.ts
+++ b/src/helpers/StatsClient.spec.ts
@@ -6,8 +6,6 @@ import winston from 'winston';
 
 import { MetricsType, StatsClient } from './StatsClient';
 
-const delay = (interval: number) => new Promise((resolve) => setTimeout(resolve, interval));
-
 describe('statsClient', () => {
   let statsClient: StatsClient;
   const logger = winston.createLogger({
@@ -41,15 +39,11 @@ describe('statsClient', () => {
       },
     });
 
-    await delay(75);
-
     expect(spyFnIncr.callCount).to.be.eq(1);
     expect(spyFnIncr.getCall(0).args).to.be.eqls(['processed_users', 4, { datamart_id: '4521' }]);
 
     expect(spyFnGauge.callCount).to.be.eq(1);
     expect(spyFnGauge.getCall(0).args).to.be.eqls(['users_with_mobile_id_count', 1, { datamart_id: '4521' }]);
-
-    await delay(50);
 
     statsClient.addOrUpdateMetrics({
       metrics: {
@@ -62,15 +56,12 @@ describe('statsClient', () => {
       metrics: { apiCallsError: { type: MetricsType.INCREMENT, value: 3, tags: { statusCode: '500' } } },
     });
 
-    await delay(25);
+    expect(spyFnIncr.callCount).to.be.eq(3);
+    expect(spyFnIncr.getCall(1).args).to.be.eqls(['processed_users', 2, { datamart_id: '4521' }]);
+    expect(spyFnIncr.getCall(2).args).to.be.eqls(['apiCallsError', 3, { statusCode: '500' }]);
 
-    expect(spyFnIncr.callCount).to.be.eq(4);
-    expect(spyFnIncr.getCall(2).args).to.be.eqls(['processed_users', 2, { datamart_id: '4521' }]);
-    expect(spyFnIncr.getCall(3).args).to.be.eqls(['apiCallsError', 3, { statusCode: '500' }]);
+    expect(spyFnGauge.callCount).to.be.eq(2);
+    expect(spyFnGauge.getCall(1).args).to.be.eqls(['users_with_mobile_id_count', 1, { datamart_id: '4521' }]);
 
-    expect(spyFnGauge.callCount).to.be.eq(3);
-    expect(spyFnGauge.getCall(2).args).to.be.eqls(['users_with_mobile_id_count', 2, { datamart_id: '4521' }]);
-
-    await delay(100);
   });
 });


### PR DESCRIPTION
There is a metrics buffer implemented in StatsClient. This commit removes this buffer and uses the one that is already implemented in the lib that we use.