### PR TITLE
MICS-17562 Improve typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 # Unreleased
 
+- Make `UserIdentifierInfo` an union type, which will help infering type based on `type`.
+- Use `UserDeviceTechnicalIdentifierType` for `registry_type` in `IdentifyingDeviceTechnicalId` instead of previous union type duplicated.
+
 # 0.19.0 - 2023-11-09
 
 - Update `UserDeviceTechnicalIdentifierType` with `TV_ADVERTISING_ID`

--- a/src/mediarithmics/api/core/plugin/ValueInterface.ts
+++ b/src/mediarithmics/api/core/plugin/ValueInterface.ts
@@ -1,3 +1,5 @@
+import { UserDeviceTechnicalIdentifierType } from "../../reference/UserIdentifierInterface";
+
 export interface AssetFilePropertyResource {
   original_file_name?: string;
   original_name?: string;
@@ -76,14 +78,6 @@ export interface NativeImagePropertyResource {
   file_path?: string;
 }
 
-export type DeviceIdRegistryType =
-  | 'INSTALLATION_ID'
-  | 'MUM_ID'
-  | 'NETWORK_DEVICE_ID'
-  | 'CUSTOM_DEVICE_ID'
-  | 'MOBILE_ADVERTISING_ID'
-  | 'MOBILE_VENDOR_ID'
-  | 'TV_ADVERTISING_ID';
 
 export interface IdentifyingAccount {
   type: 'USER_ACCOUNT';
@@ -96,7 +90,7 @@ export interface IdentifyingEmail {
 
 export interface IdentifyingDeviceTechnicalId {
   type: 'USER_DEVICE_TECHNICAL_ID';
-  registry_type: DeviceIdRegistryType;
+  registry_type: UserDeviceTechnicalIdentifierType;
   registry_id?: string;
 }
 

--- a/src/mediarithmics/api/reference/UserIdentifierInterface.ts
+++ b/src/mediarithmics/api/reference/UserIdentifierInterface.ts
@@ -7,9 +7,7 @@ export type TimeStamp = number; //long
 export type UserEmailIdentifierProviderResource = unknown; //TODO
 export type UserAgentInfo = unknown; //TODO
 
-export interface UserIdentifierInfo {
-  type: UserIdentifierInfoType;
-}
+export type UserIdentifierInfo = UserDevicePointIdentifierInfo | UserPointIdentifierInfo | UserEmailIdentifierInfo | UserAccountIdentifierInfo | UserAgentIdentifierInfo;
 
 export enum UserDeviceTechnicalIdentifierType {
   MUM_ID = 'MUM_ID',
@@ -30,7 +28,7 @@ export interface UserDevicePointIdentifierTechnicalIdentifierResource {
   expiration_ts?: TimeStamp;
 }
 
-export interface UserDevicePointIdentifierInfo extends UserIdentifierInfo {
+export interface UserDevicePointIdentifierInfo {
   type: 'USER_DEVICE_POINT';
   id?: string;
   device?: UserAgentInfo;
@@ -39,13 +37,13 @@ export interface UserDevicePointIdentifierInfo extends UserIdentifierInfo {
   technical_identifiers: Array<UserDevicePointIdentifierTechnicalIdentifierResource>;
 }
 
-export interface UserPointIdentifierInfo extends UserIdentifierInfo {
+export interface UserPointIdentifierInfo {
   type: 'USER_POINT';
   user_point_id: UUID;
   creation_ts: TimeStamp;
 }
 
-export interface UserEmailIdentifierInfo extends UserIdentifierInfo {
+export interface UserEmailIdentifierInfo {
   type: 'USER_EMAIL';
   hash: string;
   email?: string;
@@ -55,14 +53,14 @@ export interface UserEmailIdentifierInfo extends UserIdentifierInfo {
   providers: Array<UserEmailIdentifierProviderResource>;
 }
 
-export interface UserAccountIdentifierInfo extends UserIdentifierInfo {
+export interface UserAccountIdentifierInfo {
   type: 'USER_ACCOUNT';
   user_account_id: string;
   creation_ts: TimeStamp;
   compartment_id?: number; //To Be changed to `string` when the back will be updated
 }
 
-export interface UserAgentIdentifierInfo extends UserIdentifierInfo {
+export interface UserAgentIdentifierInfo {
   type: 'USER_AGENT';
   vector_id: VectorId;
   device?: UserAgentInfo;


### PR DESCRIPTION
- Make UserIdentifierInfo an union type, which will help infering type base on `type`. And will make code more readable.

- Use UserDeviceTechnicalIdentifierType for registry_type in IdentifyingDeviceTechnicalId instead of previous union type duplicated.