### PR TITLE
MICS-18206 Audience Feed add new /troubleshoot route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # Unreleased
 
+- Add new optional route `/troubleshoot` on AudienceSegmentExternalFeed which take `ExternalSegmentTroubleshootRequest` and return an `ExternalSegmentTroubleshootResponse`. This is will be helpful to debug feeds (example: return volumes on third party)
+
 # 0.21.0 - 2024-02-15
 
 - Refactor types for selected identifying resources for external feeds

--- a/src/mediarithmics/api/plugin/audiencefeedconnector/AudienceFeedConnectorPluginResponseInterface.ts
+++ b/src/mediarithmics/api/plugin/audiencefeedconnector/AudienceFeedConnectorPluginResponseInterface.ts
@@ -2,6 +2,7 @@ import { StatusCode } from '../../core/common/Response';
 
 export type AudienceFeedConnectorStatus = 'ok' | 'error' | 'retry' | 'no_eligible_identifier';
 export declare type AudienceFeedConnectorConnectionStatus = 'ok' | 'error' | 'external_segment_not_ready_yet';
+export declare type AudienceFeedConnectorTroubleshootStatus = 'ok' | 'error' | 'not_implemented';
 export type AudienceFeedConnectorContentType = 'text/csv' | 'application/json' | 'text/plain';
 
 export interface UserSegmentUpdatePluginResponse {
@@ -56,6 +57,12 @@ export interface ExternalSegmentCreationPluginResponse {
 export interface ExternalSegmentConnectionPluginResponse {
   status: AudienceFeedConnectorConnectionStatus;
   message?: string;
+}
+
+export interface ExternalSegmentTroubleshootResponse {
+  status: AudienceFeedConnectorTroubleshootStatus;
+  message?: string;
+  data?: {};
 }
 
 export interface AudienceFeedStatTag {

--- a/src/mediarithmics/api/plugin/audiencefeedconnector/AudienceFeedConnectorRequestInterface.ts
+++ b/src/mediarithmics/api/plugin/audiencefeedconnector/AudienceFeedConnectorRequestInterface.ts
@@ -33,3 +33,10 @@ export interface AudienceFeedBatchContext extends BatchUpdateContext {
   datamart_id: string;
   grouping_key: string;
 }
+
+export interface ExternalSegmentTroubleshootRequest {
+  feed_id: string;
+  datamart_id: string;
+  segment_id: string;
+  params?: {};
+}


### PR DESCRIPTION
Add new route /v1/troubeshoot.
This will be used primarly to retrieve volumes on third parties.