### PR TITLE
MICS-18286 Fix /troubleshoot on feed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Fix `/troubleshoot` was declared as GET instead of POST
+
 # Unreleased
 
 - Add new optional route `/troubleshoot` on AudienceSegmentExternalFeed which take `ExternalSegmentTroubleshootRequest` and return an `ExternalSegmentTroubleshootResponse`. This is will be helpful to debug feeds (example: return volumes on third party)

--- a/src/mediarithmics/plugins/audience-feed-connector/AudienceFeedConnectorBasePlugin.ts
+++ b/src/mediarithmics/plugins/audience-feed-connector/AudienceFeedConnectorBasePlugin.ts
@@ -335,7 +335,7 @@ abstract class GenericAudienceFeedConnectorBasePlugin<
   }
 
   private initTroubleshoot(): void {
-    this.app.get('/v1/troubleshoot', this.emptyBodyFilter, async (req: express.Request, res: express.Response) => {
+    this.app.post('/v1/troubleshoot', this.emptyBodyFilter, async (req: express.Request, res: express.Response) => {
       try {
         this.logger.debug(`POST /v1/troubleshoot ${JSON.stringify(req.body)}`);
 


### PR DESCRIPTION
`/troubleshoot` was declared as GET instead of POST