### PR TITLE
MICS-18136 Fix logger remove colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # Unreleased
 
+- Fix winston logger, remove colors
+
 # 0.23.0 - 2024-04-18
 
 - Update winston logger to push json format instead of raw text and enable colors

--- a/src/mediarithmics/plugins/common/BasePlugin.ts
+++ b/src/mediarithmics/plugins/common/BasePlugin.ts
@@ -194,10 +194,7 @@ export abstract class BasePlugin<CacheValue = unknown> {
     this.logger = winston.createLogger({
       transports: [
         new winston.transports.Console({
-          format: winston.format.combine(
-            winston.format.json(),
-            winston.format.colorize({ all: true }),
-          ),
+          format: winston.format.json(),
         }),
       ],
     });
@@ -215,7 +212,7 @@ export abstract class BasePlugin<CacheValue = unknown> {
       authentication_token: process.env.PLUGIN_AUTHENTICATION_TOKEN,
       worker_id: process.env.PLUGIN_WORKER_ID,
     };
-    
+
     this.initInitRoute();
     this.initStatusRoute();
     this.initLogLevelUpdateRoute();


### PR DESCRIPTION
Colors option where adding unescaped characters
which graylog can't handle.