### PR TITLE
MICS-18670 Typo batching stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # Unreleased
 
+- Fix typo batching stats, changing send_items_in_success -> sent_items_in_success and send_items_in_error -> sent_items_in_error
+
 # 0.23.1 - 2024-04-18
 
 - Fix winston logger, remove colors

--- a/README.md
+++ b/README.md
@@ -163,15 +163,15 @@ Testing Plugins is highly recommended.
 
 ## Migration from 0.16.x to 0.17.x
 
-- The `BatchUpdatePluginResponse` return now two new fields, `send_items_in_error` and `send_items_in_success`
+- The `BatchUpdatePluginResponse` return now two new fields, `sent_items_in_error` and `sent_items_in_success`
 
 ```ts
 export interface BatchUpdatePluginResponse {
   status: BatchUpdatePluginResponseStatus;
   message?: string;
   next_msg_delay_in_ms?: number;
-  send_items_in_success: number;
-  send_items_in_error: number;
+  sent_items_in_success: number;
+  sent_items_in_error: number;
 }
 ```
 

--- a/src/mediarithmics/api/core/batchupdate/BatchUpdateHandler.ts
+++ b/src/mediarithmics/api/core/batchupdate/BatchUpdateHandler.ts
@@ -34,8 +34,8 @@ export class BatchUpdateHandler<C extends BatchUpdateContext, T> {
 
         const pluginResponse: BatchUpdatePluginResponse = {
           status: response.status,
-          send_items_in_error: response.send_items_in_error,
-          send_items_in_success: response.send_items_in_success,
+          sent_items_in_error: response.sent_items_in_error,
+          sent_items_in_success: response.sent_items_in_success,
         };
 
         if (response.next_msg_delay_in_ms) {

--- a/src/mediarithmics/api/core/batchupdate/BatchUpdateInterface.ts
+++ b/src/mediarithmics/api/core/batchupdate/BatchUpdateInterface.ts
@@ -12,8 +12,8 @@ export interface BatchUpdatePluginResponse {
   status: BatchUpdatePluginResponseStatus;
   message?: string;
   next_msg_delay_in_ms?: number;
-  send_items_in_success: number;
-  send_items_in_error: number;
+  sent_items_in_success: number;
+  sent_items_in_error: number;
 }
 
 export type BatchUpdatePluginResponseStatus = 'OK' | 'ERROR' | 'RETRY';

--- a/src/tests/BatchedAudienceFeedConnector.ts
+++ b/src/tests/BatchedAudienceFeedConnector.ts
@@ -39,8 +39,8 @@ class MyFakeBatchedAudienceFeedConnector extends core.BatchedAudienceFeedConnect
     const response: BatchUpdatePluginResponse = {
       status: 'OK',
       message: JSON.stringify(request.batch_content),
-      send_items_in_error: 0,
-      send_items_in_success: request.batch_content.length,
+      sent_items_in_error: 0,
+      sent_items_in_success: request.batch_content.length,
     };
     return Promise.resolve(response);
   }


### PR DESCRIPTION
Fix typo batching stats, changing:
- send_items_in_success -> sent_items_in_success
- send_items_in_error -> sent_items_in_error