### PR TITLE
MICS-19677 add success/error stats for each operation_type in plugin SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 # Unreleased
 
 - Add DeviceIdRegistryResource class and DeviceIdRegistryType enum
+- Remove fields `sent_items_in_error` and `sent_items_in_success` from `BatchUpdatePluginResponse`.
+- Add instead the field `stats` which is an Array of `BatchUpdatePluginResponseStat` containing `errors`, `successes` and `operation` fields.
 
 # 0.25.0 - 2024-06-11
 

--- a/examples/audience-feed/src/ExampleAudienceFeed.ts
+++ b/examples/audience-feed/src/ExampleAudienceFeed.ts
@@ -110,8 +110,13 @@ export class ExampleAudienceFeed extends core.BatchedAudienceFeedConnectorBasePl
     const response: core.BatchUpdatePluginResponse = {
       status: 'OK',
       message: 'test_batch_update',
-      sent_items_in_error: 0,
-      sent_items_in_success: request.batch_content.length,
+      stats: [
+        {
+          successes: request.batch_content.length,
+          errors: 0,
+          operation: 'UPSERT',
+        },
+      ],
     };
     return Promise.resolve(response);
   }

--- a/examples/audience-feed/src/tests/index.ts
+++ b/examples/audience-feed/src/tests/index.ts
@@ -126,8 +126,9 @@ describe.only('Test Audience Feed example', function () {
                     expect(response.status).to.eq(200);
                     const body: core.BatchUpdatePluginResponse = JSON.parse(response.text);
                     expect(body.message).to.eq('test_batch_update');
-                    expect(body.sent_items_in_error).to.eq(0);
-                    expect(body.sent_items_in_success).to.eq(2);
+                    expect(body.stats[0].errors).to.eq(0);
+                    expect(body.stats[0].successes).to.eq(2);
+                    expect(body.stats[0].operation).to.eq('UPSERT');
                     done();
                   });
               });

--- a/src/mediarithmics/api/core/batchupdate/BatchUpdateHandler.ts
+++ b/src/mediarithmics/api/core/batchupdate/BatchUpdateHandler.ts
@@ -34,8 +34,7 @@ export class BatchUpdateHandler<C extends BatchUpdateContext, T> {
 
         const pluginResponse: BatchUpdatePluginResponse = {
           status: response.status,
-          sent_items_in_error: response.sent_items_in_error,
-          sent_items_in_success: response.sent_items_in_success,
+          stats: response.stats,
         };
 
         if (response.next_msg_delay_in_ms) {

--- a/src/mediarithmics/api/core/batchupdate/BatchUpdateInterface.ts
+++ b/src/mediarithmics/api/core/batchupdate/BatchUpdateInterface.ts
@@ -1,3 +1,5 @@
+import { UpdateType } from '../../plugin/audiencefeedconnector/AudienceFeedConnectorRequestInterface';
+
 export interface BatchUpdateContext {
   endpoint: string;
   grouping_key: string;
@@ -12,8 +14,13 @@ export interface BatchUpdatePluginResponse {
   status: BatchUpdatePluginResponseStatus;
   message?: string;
   next_msg_delay_in_ms?: number;
-  sent_items_in_success: number;
-  sent_items_in_error: number;
+  stats: BatchUpdatePluginResponseStat[];
+}
+
+export interface BatchUpdatePluginResponseStat {
+  successes: number;
+  errors: number;
+  operation: UpdateType | 'UNKNOWN';
 }
 
 export type BatchUpdatePluginResponseStatus = 'OK' | 'ERROR' | 'RETRY';

--- a/src/tests/BatchedAudienceFeedConnector.ts
+++ b/src/tests/BatchedAudienceFeedConnector.ts
@@ -39,8 +39,13 @@ class MyFakeBatchedAudienceFeedConnector extends core.BatchedAudienceFeedConnect
     const response: BatchUpdatePluginResponse = {
       status: 'OK',
       message: JSON.stringify(request.batch_content),
-      sent_items_in_error: 0,
-      sent_items_in_success: request.batch_content.length,
+      stats: [
+        {
+          successes: request.batch_content.length,
+          errors: 0,
+          operation: 'UPSERT',
+        },
+      ],
     };
     return Promise.resolve(response);
   }


### PR DESCRIPTION
Remove fields `sent_items_in_error` and `sent_items_in_success` from `BatchUpdatePluginResponse`. 
Add instead the field `stats` which is an Array of `BatchUpdatePluginResponseStat` containing `errors`, `successes` and `operation` fields. 
It will be used for getting specific error rate for each operation type