### PR TITLE
MICS-19771 Realm check in feeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # Unreleased
 
+- Add functions to fetch and check user agent identifier realm selection resources for external feeds
+
 # 0.26.1 - 2024-06-14
 
 - Add missing export for DeviceIdRegistryResource and DeviceIdRegistryDatamartSelectionResource

--- a/src/mediarithmics/api/core/webdomain/UserAgentIdentifierRealmSelectionInterface.ts
+++ b/src/mediarithmics/api/core/webdomain/UserAgentIdentifierRealmSelectionInterface.ts
@@ -1,0 +1,51 @@
+import { DataListResponse } from '../common/Response';
+
+export type RealmType = 'MEDIARITHMICS' | 'MOBILE' | 'WEB_DOMAIN' | 'GOOGLE_OPERATOR' | 'APP_NEXUS_OPERATOR' | 'ETAG';
+
+export interface WebDomainResource {
+  id: string;
+  organisation_id: string;
+  name: string;
+  sld_name: string;
+  token?: string;
+  user_id_key?: string;
+  user_id_max_age?: number;
+  auto_create_cookie?: boolean;
+  cookie_matching?: boolean;
+  cookie_matching_out?: string;
+  private_key?: string;
+  tcf_vendor_id?: number;
+  enable_tcf_on_get_user_agent_id?: boolean;
+  enable_tcf_on_set_user_agent_id?: boolean;
+}
+
+export interface UserAgentIdentifierRealmSelectionResource {
+  id: string;
+  datamart_id: string;
+  realm_type: RealmType;
+  matching?: boolean;
+  url?: string;
+  web_domain: WebDomainResource;
+}
+
+export type UserAgentIdentifierRealmSelectionResourcesResponse =
+  DataListResponse<UserAgentIdentifierRealmSelectionResource>;
+
+interface AbstractRealmFilter {
+  realmType: RealmType;
+}
+
+export interface WebDomainRealmFilter extends AbstractRealmFilter {
+  realmType: 'WEB_DOMAIN';
+  sld_name: string;
+}
+
+export interface OtherRealmFilter extends AbstractRealmFilter {
+  realmType: 'MEDIARITHMICS' | 'MOBILE' | 'GOOGLE_OPERATOR' | 'APP_NEXUS_OPERATOR' | 'ETAG';
+}
+
+export type RealmFilter = WebDomainRealmFilter | OtherRealmFilter;
+
+export const isWebDomainRealmFilter = (filter: RealmFilter): filter is WebDomainRealmFilter => {
+  return filter.realmType === 'WEB_DOMAIN';
+};

--- a/src/mediarithmics/index.ts
+++ b/src/mediarithmics/index.ts
@@ -8,6 +8,7 @@ export * from './api/core/emailrouter/EmailRouterInterface';
 export * from './api/core/plugin/PluginPropertyInterface';
 export * from './api/core/plugin/ValueInterface';
 export * from './api/core/compartment/Compartment';
+export * from './api/core/webdomain/UserAgentIdentifierRealmSelectionInterface';
 export * from './api/datamart';
 export * from './api/plugin/audiencefeedconnector/AudienceFeedConnectorPluginResponseInterface';
 export * from './api/plugin/audiencefeedconnector/AudienceFeedConnectorRequestInterface';

--- a/src/tests/AudienceFeedConnector.ts
+++ b/src/tests/AudienceFeedConnector.ts
@@ -8,12 +8,7 @@ import sinon from 'sinon';
 import request from 'supertest';
 
 import { core } from '../';
-import {
-  AudienceFeedBatchContext,
-  BatchedUserSegmentUpdatePluginResponse,
-  UserSegmentUpdatePluginBatchDeliveryResponseData,
-  UserSegmentUpdatePluginFileDeliveryResponseData,
-} from '../mediarithmics';
+import { AudienceFeedBatchContext, UserSegmentUpdatePluginFileDeliveryResponseData } from '../mediarithmics';
 import { BatchUpdateRequest } from '../mediarithmics/api/core/batchupdate/BatchUpdateInterface';
 
 const PLUGIN_AUTHENTICATION_TOKEN = 'Manny';


### PR DESCRIPTION
This commit defines functions to get user agent identifier realm selections for a given datamart, and to check that there exists one realm with a given realm type. These functions can be used in an audience feed connector.