### PR TITLE
MICS-20001 reintroduce sent_items_in_success and sent_items_in_error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 # Unreleased
 
-- Add new Error classes to have generic end user messages: `MissingConfigurationPropertyError`, 
-`InvalidPropertyValueError`, `FileDownloadError` and `MissingRealmError`.
+- Add new Error classes to have generic end user messages: `MissingConfigurationPropertyError`,
+  `InvalidPropertyValueError`, `FileDownloadError` and `MissingRealmError`.
+
+- The field `stats` has been removed from `BatchUpdatePluginResponse`.
+- The fields `sent_items_in_error` and `sent_items_in_success` are reintroduced instead.
 
 # 0.27.0 - 2024-06-27
 

--- a/README.md
+++ b/README.md
@@ -161,6 +161,11 @@ The Plugin examples provided with the SDK are all tested and you can read their 
 
 Testing Plugins is highly recommended.
 
+## Migration from 0.27.x to 0.28.x
+
+The field `stats` has been removed from `BatchUpdatePluginResponse`.
+The fields `sent_items_in_error` and `sent_items_in_success` are reintroduced instead.
+
 ## Migration from 0.25.x to 0.26.x
 
 The fields `sent_items_in_error` and `sent_items_in_success` from `BatchUpdatePluginResponse` has been removed.

--- a/examples/audience-feed/src/ExampleAudienceFeed.ts
+++ b/examples/audience-feed/src/ExampleAudienceFeed.ts
@@ -34,14 +34,16 @@ export class ExampleAudienceFeed extends core.BatchedAudienceFeedConnectorBasePl
     // If you need to check a property in an enum/union type/...
     // throw new core.InvalidPropertyValueError(feedId, 'my_property', 'TATO', ['TOTO', 'TATA']);
 
-    const configFile = this.fetchConfigurationFile(CONFIG_FILE_NAME).then(file => {
-      // throw new core.MissingConfigurationPropertyError(feedId, 'config_option');
-    }).catch((error) => {
-      const message = `Error fetching config file ${CONFIG_FILE_NAME}`;
-      LoggerWrapper.logger.error(message, error);
-      // For error on file download, use FileDownloadError as it will generate a generic message to the end user
-      throw new core.FileDownloadError(feedId, CONFIG_FILE_NAME);
-    });
+    const configFile = this.fetchConfigurationFile(CONFIG_FILE_NAME)
+      .then((file) => {
+        // throw new core.MissingConfigurationPropertyError(feedId, 'config_option');
+      })
+      .catch((error) => {
+        const message = `Error fetching config file ${CONFIG_FILE_NAME}`;
+        LoggerWrapper.logger.error(message, error);
+        // For error on file download, use FileDownloadError as it will generate a generic message to the end user
+        throw new core.FileDownloadError(feedId, CONFIG_FILE_NAME);
+      });
 
     // If you want a customized message for the end user you can use AudienceFeedInstanceContextError
     // throw new core.AudienceFeedInstanceContextError('Example public message');
@@ -120,13 +122,8 @@ export class ExampleAudienceFeed extends core.BatchedAudienceFeedConnectorBasePl
     const response: core.BatchUpdatePluginResponse = {
       status: 'OK',
       message: 'test_batch_update',
-      stats: [
-        {
-          successes: request.batch_content.length,
-          errors: 0,
-          operation: 'UPSERT',
-        },
-      ],
+      sent_items_in_success: request.batch_content.length,
+      sent_items_in_error: 0,
     };
     return Promise.resolve(response);
   }

--- a/examples/audience-feed/src/tests/index.ts
+++ b/examples/audience-feed/src/tests/index.ts
@@ -126,9 +126,8 @@ describe.only('Test Audience Feed example', function () {
                     expect(response.status).to.eq(200);
                     const body: core.BatchUpdatePluginResponse = JSON.parse(response.text);
                     expect(body.message).to.eq('test_batch_update');
-                    expect(body.stats[0].errors).to.eq(0);
-                    expect(body.stats[0].successes).to.eq(2);
-                    expect(body.stats[0].operation).to.eq('UPSERT');
+                    expect(body.sent_items_in_error).to.eq(0);
+                    expect(body.sent_items_in_success).to.eq(2);
                     done();
                   });
               });

--- a/src/mediarithmics/api/core/batchupdate/BatchUpdateHandler.ts
+++ b/src/mediarithmics/api/core/batchupdate/BatchUpdateHandler.ts
@@ -34,7 +34,8 @@ export class BatchUpdateHandler<C extends BatchUpdateContext, T> {
 
         const pluginResponse: BatchUpdatePluginResponse = {
           status: response.status,
-          stats: response.stats,
+          sent_items_in_success: response.sent_items_in_success,
+          sent_items_in_error: response.sent_items_in_error,
         };
 
         if (response.next_msg_delay_in_ms) {

--- a/src/mediarithmics/api/core/batchupdate/BatchUpdateInterface.ts
+++ b/src/mediarithmics/api/core/batchupdate/BatchUpdateInterface.ts
@@ -14,13 +14,8 @@ export interface BatchUpdatePluginResponse {
   status: BatchUpdatePluginResponseStatus;
   message?: string;
   next_msg_delay_in_ms?: number;
-  stats: BatchUpdatePluginResponseStat[];
-}
-
-export interface BatchUpdatePluginResponseStat {
-  successes: number;
-  errors: number;
-  operation: UpdateType | 'UNKNOWN';
+  sent_items_in_success: number;
+  sent_items_in_error: number;
 }
 
 export type BatchUpdatePluginResponseStatus = 'OK' | 'ERROR' | 'RETRY';

--- a/src/tests/BatchedAudienceFeedConnector.ts
+++ b/src/tests/BatchedAudienceFeedConnector.ts
@@ -39,13 +39,8 @@ class MyFakeBatchedAudienceFeedConnector extends core.BatchedAudienceFeedConnect
     const response: BatchUpdatePluginResponse = {
       status: 'OK',
       message: JSON.stringify(request.batch_content),
-      stats: [
-        {
-          successes: request.batch_content.length,
-          errors: 0,
-          operation: 'UPSERT',
-        },
-      ],
+      sent_items_in_success: request.batch_content.length,
+      sent_items_in_error: 0,
     };
     return Promise.resolve(response);
   }


### PR DESCRIPTION
reintroduce sent_items_in_success and sent_items_in_error instead of stats field in BatchUpdatePluginResponse