### PR TITLE
MICS-20510 Update Computed Field plugins structure 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # Unreleased
 
+- Breaking change in computed field sdk: Replace the onUpdate method with 3 distinct methods (one for UserActivity updates, one for UserProfile and one for ComputedField).
+
 # 0.28.2 - 2024-08-27
 
 - Fix computed fields APIs serialization and deserialization.

--- a/examples/computed-field/package.json
+++ b/examples/computed-field/package.json
@@ -11,7 +11,7 @@
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "@mediarithmics/plugins-nodejs-sdk": "^0.21.0"
+    "@mediarithmics/plugins-nodejs-sdk": "^0.28.2"
   },
   "devDependencies": {
     "@types/chai": "4.3.14",

--- a/examples/computed-field/package.json
+++ b/examples/computed-field/package.json
@@ -9,7 +9,7 @@
     "build": "tsc"
   },
   "author": "",
-  "license": "Apache-2.0",
+  "license": "UNLICENSED",
   "dependencies": {
     "@mediarithmics/plugins-nodejs-sdk": "^0.28.2"
   },

--- a/examples/computed-field/src/MyComputedField.ts
+++ b/examples/computed-field/src/MyComputedField.ts
@@ -1,6 +1,11 @@
 import { core } from '@mediarithmics/plugins-nodejs-sdk';
+import {
+  BaseUserActivity,
+  BaseUserProfile,
+  BaseComputedField,
+} from '../../../lib/mediarithmics/plugins/computed-field/ComputedFieldBasePlugin';
 
-export interface Event {
+interface Event {
   basketPrice: number;
 }
 
@@ -8,26 +13,36 @@ export interface State {
   totalSpentAmount: number;
 }
 
-export interface Data {
-  events: Event[];
-}
-
 export interface Result {
   score: number;
 }
 
-export class MyComputedField extends core.ComputedFieldPlugin<State, Data, Result> {
+interface UserActivity extends BaseUserActivity {
+  events: Event[];
+}
+
+interface UserProfile extends BaseUserProfile {}
+
+interface ComputedField extends BaseComputedField {}
+
+export class MyComputedField extends core.ComputedFieldPlugin<State, Result, UserActivity, UserProfile, ComputedField> {
   constructor() {
     super();
   }
 
-  onUpdate(state: State | null, data: Data): State {
+  onUpdateActivity(state: State, userActivity: UserActivity): State {
     if (!state) {
       state = { totalSpentAmount: 0 };
     }
 
-    data.events.map((event) => (state.totalSpentAmount += event.basketPrice));
+    userActivity.events.map((event) => (state.totalSpentAmount += event.basketPrice));
 
+    return state;
+  }
+  onUpdateUserProfile(state: State, userProfile: UserProfile, operation: core.Operation): State {
+    return state;
+  }
+  onUpdateComputedField(state: State, computedField: ComputedField): State {
     return state;
   }
 

--- a/examples/computed-field/src/MyComputedField.ts
+++ b/examples/computed-field/src/MyComputedField.ts
@@ -1,12 +1,15 @@
 import { core } from '@mediarithmics/plugins-nodejs-sdk';
 
+export interface Event {
+  basketPrice: number;
+}
+
 export interface State {
-  ts: number;
-  amount: number;
+  totalSpentAmount: number;
 }
 
 export interface Data {
-  events: State[];
+  events: Event[];
 }
 
 export interface Result {
@@ -18,26 +21,17 @@ export class MyComputedField extends core.ComputedFieldPlugin<State, Data, Resul
     super();
   }
 
-  dataReduce(data: Data): State {
-    return data.events.reduce((acc, curr) => {
-      return { ...acc, ...curr };
-    });
-  }
-
   onUpdate(state: State | null, data: Data): State {
     if (!state) {
-      return this.dataReduce(data);
+      state = { totalSpentAmount: 0 };
     }
-    return { ...state, ...this.dataReduce(data) };
+
+    data.events.map((event) => (state.totalSpentAmount += event.basketPrice));
+
+    return state;
   }
 
-  buildResult(state: State | null): {
-    state: State | null;
-    result: Result;
-  } {
-    return {
-      state: state,
-      result: { score: 1 },
-    };
+  buildResult(state: State | null): Result {
+    return { score: state.totalSpentAmount };
   }
 }

--- a/examples/computed-field/src/tests/MyComputedField.test.ts
+++ b/examples/computed-field/src/tests/MyComputedField.test.ts
@@ -4,8 +4,8 @@ import 'mocha';
 
 import { core } from '@mediarithmics/plugins-nodejs-sdk';
 import { expect } from 'chai';
-import * as ion from 'ion-js';
 import { MyComputedField, Result, State } from '../MyComputedField';
+import { DataType, Operation } from '../../../../lib/mediarithmics/plugins/computed-field/ComputedFieldBasePlugin';
 
 process.env.PLUGIN_WORKER_ID = 'Calavera';
 process.env.PLUGIN_AUTHENTICATION_TOKEN = 'Manny';
@@ -18,8 +18,10 @@ describe('ClientComputedField - json data', function () {
     runner = new core.TestingPluginRunner(plugin);
 
     const data = {
-      data: {
-        events: [{ basketPrice: 1 }, { basketPrice: 2 }, { basketPrice: 3 }, { basketPrice: 2 }],
+      update: {
+        dataType: DataType.USER_ACTIVITY,
+        operation: Operation.INSERT,
+        data: { events: [{ basketPrice: 1 }, { basketPrice: 2 }, { basketPrice: 3 }, { basketPrice: 2 }] },
       },
     };
     const response = JSON.parse(
@@ -39,8 +41,12 @@ describe('ClientComputedField - json data', function () {
 
     const data = {
       state: { totalSpentAmount: 10 },
-      data: {
-        events: [{ basketPrice: 1 }, { basketPrice: 2 }, { basketPrice: 3 }, { basketPrice: 2 }],
+      update: {
+        dataType: DataType.USER_ACTIVITY,
+        operation: Operation.INSERT,
+        data: {
+          events: [{ basketPrice: 1 }, { basketPrice: 2 }, { basketPrice: 3 }, { basketPrice: 2 }],
+        },
       },
     };
 
@@ -59,10 +65,16 @@ describe('ClientComputedField - json data', function () {
 
     const data = {
       state: { totalSpentAmount: 55 },
-      data: [
-        { events: [{ basketPrice: 1 }] },
+      updates: [
         {
-          events: [{ basketPrice: 2 }, { basketPrice: 3 }],
+          dataType: DataType.USER_ACTIVITY,
+          operation: Operation.INSERT,
+          data: { events: [{ basketPrice: 1 }] },
+        },
+        {
+          dataType: DataType.USER_ACTIVITY,
+          operation: Operation.INSERT,
+          data: { events: [{ basketPrice: 2 }, { basketPrice: 3 }] },
         },
       ],
     };
@@ -82,10 +94,16 @@ describe('ClientComputedField - json data', function () {
 
     const data1 = {
       state: { totalSpentAmount: 55 },
-      data: [
-        { events: [{ basketPrice: 1 }] },
+      updates: [
         {
-          events: [{ basketPrice: 2 }, { basketPrice: 3 }],
+          dataType: DataType.USER_ACTIVITY,
+          operation: Operation.INSERT,
+          data: { events: [{ basketPrice: 1 }] },
+        },
+        {
+          dataType: DataType.USER_ACTIVITY,
+          operation: Operation.INSERT,
+          data: { events: [{ basketPrice: 2 }, { basketPrice: 3 }] },
         },
       ],
     };
@@ -101,10 +119,16 @@ describe('ClientComputedField - json data', function () {
 
     const data2 = {
       state: update1.data.state,
-      data: [
-        { events: [{ basketPrice: 2 }] },
+      updates: [
         {
-          events: [{ basketPrice: 4 }, { basketPrice: 6 }],
+          dataType: DataType.USER_ACTIVITY,
+          operation: Operation.INSERT,
+          data: { events: [{ basketPrice: 2 }] },
+        },
+        {
+          dataType: DataType.USER_ACTIVITY,
+          operation: Operation.INSERT,
+          data: { events: [{ basketPrice: 4 }, { basketPrice: 6 }] },
         },
       ],
     };

--- a/examples/computed-field/src/tests/MyComputedField.test.ts
+++ b/examples/computed-field/src/tests/MyComputedField.test.ts
@@ -5,140 +5,52 @@ import 'mocha';
 import { core } from '@mediarithmics/plugins-nodejs-sdk';
 import { expect } from 'chai';
 import * as ion from 'ion-js';
-import { MyComputedField, State } from '../MyComputedField';
+import { MyComputedField, Result, State } from '../MyComputedField';
 
 process.env.PLUGIN_WORKER_ID = 'Calavera';
 process.env.PLUGIN_AUTHENTICATION_TOKEN = 'Manny';
-
-// Ion data tests are skiped because we are not using ion format yet
-describe.skip('ClientComputedField - ion data', function () {
-  const plugin = new MyComputedField();
-  let runner: core.TestingPluginRunner;
-
-  it('update route', async () => {
-    runner = new core.TestingPluginRunner(plugin);
-    const ionData =
-      '{state:{ts:33,amount:55},data:{events:[{ts:1,amount:1},{ts:2,amount:2},{ts:3,amount:3},{ts:2,amount:2}]}}';
-    const response = await request(runner.plugin.app).post('/v1/computed_field/update/single').send({ data: ionData });
-
-    expect((response.body as core.OnUpdatePluginResponse<State>).status).to.deep.equal('ok');
-    expect((response.body as core.OnUpdatePluginResponse<State>).data).to.deep.equal({
-      ts: 2,
-      amount: 2,
-    });
-  });
-
-  it('update route with null state', async () => {
-    runner = new core.TestingPluginRunner(plugin);
-
-    const ionData = '{state:null,data:{events:[{ts:1,amount:1},{ts:2,amount:2},{ts:3,amount:3},{ts:2,amount:2}]}}';
-    const response = await request(runner.plugin.app).post('/v1/computed_field/update/single').send({ data: ionData });
-
-    expect((response.body as core.OnUpdatePluginResponse<State>).status).to.deep.equal('ok');
-    expect((response.body as core.OnUpdatePluginResponse<State>).data).to.deep.equal({
-      ts: 2,
-      amount: 2,
-    });
-  });
-
-  it('update batch route', async () => {
-    runner = new core.TestingPluginRunner(plugin);
-
-    const ionData =
-      '{state:{ts:33,amount:55},data:[{events:[{ts:1,amount:1}]},{events:[{ts:2,amount:2},{ts:3,amount:3}]}]}';
-    const response = await request(runner.plugin.app).post('/v1/computed_field/update/batch').send({ data: ionData });
-    expect((response.body as core.OnUpdatePluginResponse<State>).status).to.deep.equal('ok');
-    expect((response.body as core.OnUpdatePluginResponse<State>).data).to.deep.equal({
-      ts: 3,
-      amount: 3,
-    });
-  });
-
-  it('build result route', async () => {
-    runner = new core.TestingPluginRunner(plugin);
-
-    const ionData1 =
-      '{state:{ts:33,amount:55},data:[{events:[{ts:1,amount:1}]},{events:[{ts:2,amount:2},{ts:3,amount:3}]}]}';
-    const update1 = await request(runner.plugin.app).post('/v1/computed_field/update/batch').send({ data: ionData1 });
-    expect((update1.body as core.OnUpdatePluginResponse<State>).status).to.deep.equal('ok');
-    expect((update1.body as core.OnUpdatePluginResponse<State>).data).to.deep.equal({
-      ts: 3,
-      amount: 3,
-    });
-
-    const state1 = ion.dumpText((update1.body as core.OnUpdatePluginResponse<State>).data);
-
-    const ionData2 = `{state:${state1},data:[{events:[{ts:2,amount:2}]},{events:[{ts:4,amount:4},{ts:6,amount:6}]}]}`;
-    const update2 = await request(runner.plugin.app).post('/v1/computed_field/update/batch').send({ data: ionData2 });
-    expect((update2.body as core.OnUpdatePluginResponse<State>).status).to.deep.equal('ok');
-    expect((update2.body as core.OnUpdatePluginResponse<State>).data).to.deep.equal({
-      ts: 6,
-      amount: 6,
-    });
-
-    const state2 = ion.dumpText((update2.body as core.OnUpdatePluginResponse<State>).data);
-    const buildResult = await request(runner.plugin.app).post('/v1/computed_field/build_result').send({ data: state2 });
-    expect((buildResult.body as core.OnUpdatePluginResponse<State>).status).to.deep.equal('ok');
-    expect((buildResult.body as core.OnUpdatePluginResponse<State>).data).to.deep.equal({
-      result: {
-        score: 1,
-      },
-      state: {
-        ts: 6,
-        amount: 6,
-      },
-    });
-  });
-});
 
 describe('ClientComputedField - json data', function () {
   const plugin = new MyComputedField();
   let runner: core.TestingPluginRunner;
 
-  it('update route', async () => {
-    runner = new core.TestingPluginRunner(plugin);
-
-    const data = {
-      state: { ts: 33, amount: 55 },
-      data: {
-        events: [
-          { ts: 1, amount: 1 },
-          { ts: 2, amount: 2 },
-          { ts: 3, amount: 3 },
-          { ts: 2, amount: 2 },
-        ],
-      },
-    };
-    const jsonData = JSON.stringify(data);
-    const response = await request(runner.plugin.app).post('/v1/computed_field/update/single').send({ data: jsonData });
-
-    expect((response.body as core.OnUpdatePluginResponse<State>).status).to.deep.equal('ok');
-    expect((response.body as core.OnUpdatePluginResponse<State>).data).to.deep.equal({
-      ts: 2,
-      amount: 2,
-    });
-  });
-
   it('update route with null state', async () => {
     runner = new core.TestingPluginRunner(plugin);
 
     const data = {
       data: {
-        events: [
-          { ts: 1, amount: 1 },
-          { ts: 2, amount: 2 },
-          { ts: 3, amount: 3 },
-          { ts: 2, amount: 2 },
-        ],
+        events: [{ basketPrice: 1 }, { basketPrice: 2 }, { basketPrice: 3 }, { basketPrice: 2 }],
       },
     };
-    const jsonData = JSON.stringify(data);
-    const response = await request(runner.plugin.app).post('/v1/computed_field/update/single').send({ data: jsonData });
+    const response = JSON.parse(
+      (await request(runner.plugin.app).post('/v1/computed_field/update/single').send(JSON.stringify(data))).text,
+    ) as core.OnUpdatePluginResponse<State>;
 
-    expect((response.body as core.OnUpdatePluginResponse<State>).status).to.deep.equal('ok');
-    expect((response.body as core.OnUpdatePluginResponse<State>).data).to.deep.equal({
-      ts: 2,
-      amount: 2,
+    expect(response.status).to.deep.equal('ok');
+    expect(response.data).to.deep.equal({
+      state: {
+        totalSpentAmount: 8,
+      },
+    });
+  });
+
+  it('update route with state', async () => {
+    runner = new core.TestingPluginRunner(plugin);
+
+    const data = {
+      state: { totalSpentAmount: 10 },
+      data: {
+        events: [{ basketPrice: 1 }, { basketPrice: 2 }, { basketPrice: 3 }, { basketPrice: 2 }],
+      },
+    };
+
+    const response = JSON.parse(
+      (await request(runner.plugin.app).post('/v1/computed_field/update/single').send(JSON.stringify(data))).text,
+    ) as core.OnUpdatePluginResponse<State>;
+
+    expect(response.status).to.deep.equal('ok');
+    expect(response.data).to.deep.equal({
+      state: { totalSpentAmount: 18 },
     });
   });
 
@@ -146,23 +58,22 @@ describe('ClientComputedField - json data', function () {
     runner = new core.TestingPluginRunner(plugin);
 
     const data = {
-      state: { ts: 33, amount: 55 },
+      state: { totalSpentAmount: 55 },
       data: [
-        { events: [{ ts: 1, amount: 1 }] },
+        { events: [{ basketPrice: 1 }] },
         {
-          events: [
-            { ts: 2, amount: 2 },
-            { ts: 3, amount: 3 },
-          ],
+          events: [{ basketPrice: 2 }, { basketPrice: 3 }],
         },
       ],
     };
-    const jsonData = JSON.stringify(data);
-    const response = await request(runner.plugin.app).post('/v1/computed_field/update/batch').send({ data: jsonData });
-    expect((response.body as core.OnUpdatePluginResponse<State>).status).to.deep.equal('ok');
-    expect((response.body as core.OnUpdatePluginResponse<State>).data).to.deep.equal({
-      ts: 3,
-      amount: 3,
+
+    const response = JSON.parse(
+      (await request(runner.plugin.app).post('/v1/computed_field/update/batch').send(JSON.stringify(data))).text,
+    ) as core.OnUpdatePluginResponse<State>;
+
+    expect(response.status).to.deep.equal('ok');
+    expect(response.data).to.deep.equal({
+      state: { totalSpentAmount: 61 },
     });
   });
 
@@ -170,61 +81,51 @@ describe('ClientComputedField - json data', function () {
     runner = new core.TestingPluginRunner(plugin);
 
     const data1 = {
-      state: { ts: 33, amount: 55 },
+      state: { totalSpentAmount: 55 },
       data: [
-        { events: [{ ts: 1, amount: 1 }] },
+        { events: [{ basketPrice: 1 }] },
         {
-          events: [
-            { ts: 2, amount: 2 },
-            { ts: 3, amount: 3 },
-          ],
+          events: [{ basketPrice: 2 }, { basketPrice: 3 }],
         },
       ],
     };
-    const jsonData1 = JSON.stringify(data1);
-    const update1 = await request(runner.plugin.app).post('/v1/computed_field/update/batch').send({ data: jsonData1 });
-    expect((update1.body as core.OnUpdatePluginResponse<State>).status).to.deep.equal('ok');
-    expect((update1.body as core.OnUpdatePluginResponse<State>).data).to.deep.equal({
-      ts: 3,
-      amount: 3,
-    });
 
-    const state1 = (update1.body as core.OnUpdatePluginResponse<State>).data;
+    const update1 = JSON.parse(
+      (await request(runner.plugin.app).post('/v1/computed_field/update/batch').send(JSON.stringify(data1))).text,
+    ) as core.OnUpdatePluginResponse<State>;
+
+    expect(update1.status).to.deep.equal('ok');
+    expect(update1.data).to.deep.equal({
+      state: { totalSpentAmount: 61 },
+    });
 
     const data2 = {
-      state: state1,
+      state: update1.data.state,
       data: [
-        { events: [{ ts: 2, amount: 2 }] },
+        { events: [{ basketPrice: 2 }] },
         {
-          events: [
-            { ts: 4, amount: 4 },
-            { ts: 6, amount: 6 },
-          ],
+          events: [{ basketPrice: 4 }, { basketPrice: 6 }],
         },
       ],
     };
-    const jsonData2 = JSON.stringify(data2);
-    const update2 = await request(runner.plugin.app).post('/v1/computed_field/update/batch').send({ data: jsonData2 });
-    expect((update2.body as core.OnUpdatePluginResponse<State>).status).to.deep.equal('ok');
-    expect((update2.body as core.OnUpdatePluginResponse<State>).data).to.deep.equal({
-      ts: 6,
-      amount: 6,
+
+    const update2 = JSON.parse(
+      (await request(runner.plugin.app).post('/v1/computed_field/update/batch').send(JSON.stringify(data2))).text,
+    ) as core.OnUpdatePluginResponse<State>;
+
+    expect(update2.status).to.deep.equal('ok');
+    expect(update2.data).to.deep.equal({
+      state: { totalSpentAmount: 73 },
     });
 
-    const state2 = (update2.body as core.OnUpdatePluginResponse<State>).data;
-    const jsonState2 = JSON.stringify(state2);
-    const buildResult = await request(runner.plugin.app)
-      .post('/v1/computed_field/build_result')
-      .send({ data: jsonState2 });
-    expect((buildResult.body as core.OnUpdatePluginResponse<State>).status).to.deep.equal('ok');
-    expect((buildResult.body as core.OnUpdatePluginResponse<State>).data).to.deep.equal({
-      result: {
-        score: 1,
-      },
-      state: {
-        ts: 6,
-        amount: 6,
-      },
+    const buildResult = JSON.parse(
+      (await request(runner.plugin.app).post('/v1/computed_field/build_result').send(JSON.stringify(update2.data)))
+        .text,
+    ) as core.OnUpdatePluginResponse<Result>;
+
+    expect(buildResult.status).to.deep.equal('ok');
+    expect(buildResult.data).to.deep.equal({
+      result: { score: 73 },
     });
   });
 });

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "testOnly": "./testOnly.sh",
     "prepublishOnly": "tsc",
     "build": "tsc",
-    "docs": "typedoc --out docs/ --mode modules --target es6 --module commonjs ./src",
+    "docs": "typedoc --out docs/ ./src",
     "prettier:fix": "prettier --write '**/*.ts'",
     "test:Helper": "npm run build && NODE_ENV=development mocha lib/helpers/StatsClient.spec.js"
   },

--- a/src/mediarithmics/plugins/computed-field/ComputedFieldBasePlugin.ts
+++ b/src/mediarithmics/plugins/computed-field/ComputedFieldBasePlugin.ts
@@ -19,27 +19,55 @@ export interface OnUpdateBatchPluginResponse<S> extends PluginResponse {
   };
 }
 
-export interface BuildResultPluginResponse<D> extends PluginResponse {
+export interface BuildResultPluginResponse<R> extends PluginResponse {
   data: {
-    result: D;
+    result: R;
   };
 }
 
-export interface RequestData<S, D> {
-  state: S;
-  data: D;
+export enum DataType {
+  USER_ACTIVITY,
+  USER_PROFILE,
+  COMPUTED_FIELD,
 }
 
-export interface RequestDataBatch<S, D> {
+export enum Operation {
+  INSERT,
+  DELETE,
+  UPDATE,
+}
+
+export interface BaseUserActivity {}
+export interface BaseUserProfile {}
+export interface BaseComputedField {}
+
+export interface Update {
+  dataType: DataType;
+  operation: Operation;
+  data: BaseUserActivity | BaseUserProfile | BaseComputedField;
+}
+
+export interface RequestData<S> {
   state: S;
-  data: D[];
+  update: Update;
+}
+
+export interface RequestDataBatch<S> {
+  state: S;
+  updates: Update[];
 }
 
 export interface RequestResult<S> {
   state: S;
 }
 
-export abstract class ComputedFieldPlugin<State, Data, Result> extends BasePlugin {
+export abstract class ComputedFieldPlugin<
+  State,
+  Result,
+  UserActivity extends BaseUserActivity,
+  UserProfile extends BaseUserProfile,
+  ComputedField extends BaseComputedField,
+> extends BasePlugin {
   constructor() {
     super();
     this.initUpdateRoute();
@@ -47,13 +75,28 @@ export abstract class ComputedFieldPlugin<State, Data, Result> extends BasePlugi
     this.initBuildResultRoute();
   }
 
-  abstract onUpdate(state: State | null, data: Data): State | null;
+  abstract onUpdateActivity(state: State | null, userActivity: UserActivity): State | null;
+  abstract onUpdateUserProfile(state: State | null, userProfile: UserProfile, operation: Operation): State | null;
+  abstract onUpdateComputedField(state: State | null, computedField: ComputedField): State | null;
 
   abstract buildResult(state: State | null): Result | null;
 
-  private onUpdateBatch(state: State, data: Data[]): State | null {
-    return data.reduce((acc, curr) => {
-      return this.onUpdate(acc, curr);
+  private getUpdateMethod(state: State | null, update: Update): State | null {
+    switch (update.dataType) {
+      case DataType.USER_ACTIVITY:
+        return this.onUpdateActivity(state, update.data as UserActivity);
+      case DataType.USER_PROFILE:
+        return this.onUpdateUserProfile(state, update.data as UserProfile, update.operation);
+      case DataType.COMPUTED_FIELD:
+        return this.onUpdateComputedField(state, update.data as ComputedField);
+      default:
+        return state;
+    }
+  }
+
+  private onUpdateBatch(state: State, updates: Update[]): State | null {
+    return updates.reduce((acc, curr) => {
+      return this.getUpdateMethod(acc, curr);
     }, state);
   }
 
@@ -73,16 +116,21 @@ export abstract class ComputedFieldPlugin<State, Data, Result> extends BasePlugi
     this.app.post(
       '/v1/computed_field/update/single',
       (req: express.Request<unknown, unknown, string>, res: express.Response) => {
-        const body = this.formatRequestData<RequestData<State, Data>>(req);
-        const updatedState = this.onUpdate(body.state, body.data);
-        const pluginResponse: OnUpdatePluginResponse<State | null> = {
-          status: 'ok',
-          data: {
-            state: updatedState,
-          },
-        };
-        const response = this.formatResponse(req, pluginResponse);
-        res.status(200).send(response);
+        try {
+          const body = this.formatRequestData<RequestData<State>>(req);
+          const updatedState = this.getUpdateMethod(body.state, body.update);
+          const pluginResponse: OnUpdatePluginResponse<State | null> = {
+            status: 'ok',
+            data: {
+              state: updatedState,
+            },
+          };
+          const response = this.formatResponse(req, pluginResponse);
+          res.status(200).send(response);
+        } catch (error) {
+          this.logger.error('Something bad happened on single update route', error);
+          return res.status(500).send({ status: 'error', message: `${(error as Error).message}` });
+        }
       },
     );
   }
@@ -91,15 +139,20 @@ export abstract class ComputedFieldPlugin<State, Data, Result> extends BasePlugi
     this.app.post(
       '/v1/computed_field/update/batch',
       (req: express.Request<unknown, unknown, string>, res: express.Response) => {
-        const body = this.formatRequestData<RequestDataBatch<State, Data>>(req);
-        const updatedState = this.onUpdateBatch(body.state, body.data);
-        const pluginResponse: OnUpdatePluginResponse<State | null> = {
-          status: 'ok',
-          data: {
-            state: updatedState,
-          },
-        };
-        res.status(200).send(this.formatResponse(req, pluginResponse));
+        try {
+          const body = this.formatRequestData<RequestDataBatch<State>>(req);
+          const updatedState = this.onUpdateBatch(body.state, body.updates);
+          const pluginResponse: OnUpdatePluginResponse<State | null> = {
+            status: 'ok',
+            data: {
+              state: updatedState,
+            },
+          };
+          res.status(200).send(this.formatResponse(req, pluginResponse));
+        } catch (error) {
+          this.logger.error('Something bad happened on single update route', error);
+          return res.status(500).send({ status: 'error', message: `${(error as Error).message}` });
+        }
       },
     );
   }
@@ -108,15 +161,20 @@ export abstract class ComputedFieldPlugin<State, Data, Result> extends BasePlugi
     this.app.post(
       '/v1/computed_field/build_result',
       (req: express.Request<unknown, unknown, string>, res: express.Response) => {
-        const body = this.formatRequestData<RequestResult<State>>(req);
-        const buildResult = this.buildResult(body.state);
-        const pluginResponse: BuildResultPluginResponse<Result | null> = {
-          status: 'ok',
-          data: {
-            result: buildResult,
-          },
-        };
-        res.status(200).send(this.formatResponse(req, pluginResponse));
+        try {
+          const body = this.formatRequestData<RequestResult<State>>(req);
+          const buildResult = this.buildResult(body.state);
+          const pluginResponse: BuildResultPluginResponse<Result | null> = {
+            status: 'ok',
+            data: {
+              result: buildResult,
+            },
+          };
+          res.status(200).send(this.formatResponse(req, pluginResponse));
+        } catch (error) {
+          this.logger.error('Something bad happened on single update route', error);
+          return res.status(500).send({ status: 'error', message: `${(error as Error).message}` });
+        }
       },
     );
   }


### PR DESCRIPTION
We need to provide developers with more details when working
on computing fields, such as the type of data they are receiving
(UserActivity, UserProfile or Computed field result updates) but also
the operation that caused the update (insertion or deletion).

To do so, we need to refactor the structure of the computed field
sdk, enforcing the definition of 3 distincts updates method (one per
data type).

Developer experience should be enhanced this way.