### PR TITLE
MICS-20753 Computed fields: Use string instead of enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # Unreleased
 
+- Fix the data_type and operation in computed field sdk: Use string instead of enum to prevent deserialization issues
+
 # v0.29.1 2024-09-27
 
 - Fix the data type in in computed field sdk: snake case is used instead of the camel case

--- a/examples/computed-field/src/MyComputedField.ts
+++ b/examples/computed-field/src/MyComputedField.ts
@@ -47,6 +47,6 @@ export class MyComputedField extends core.ComputedFieldPlugin<State, Result, Use
   }
 
   buildResult(state: State | null): Result {
-    return { score: state.totalSpentAmount };
+    return { score: state ? state.totalSpentAmount : null };
   }
 }

--- a/examples/computed-field/src/tests/MyComputedField.test.ts
+++ b/examples/computed-field/src/tests/MyComputedField.test.ts
@@ -19,8 +19,8 @@ describe('ClientComputedField - json data', function () {
 
     const data = {
       update: {
-        data_type: DataType.USER_ACTIVITY,
-        operation: Operation.INSERT,
+        data_type: 'USER_ACTIVITY',
+        operation: 'INSERT',
         data: { events: [{ basketPrice: 1 }, { basketPrice: 2 }, { basketPrice: 3 }, { basketPrice: 2 }] },
       },
     };
@@ -42,8 +42,8 @@ describe('ClientComputedField - json data', function () {
     const data = {
       state: { totalSpentAmount: 10 },
       update: {
-        data_type: DataType.USER_ACTIVITY,
-        operation: Operation.INSERT,
+        data_type: 'USER_ACTIVITY',
+        operation: 'INSERT',
         data: {
           events: [{ basketPrice: 1 }, { basketPrice: 2 }, { basketPrice: 3 }, { basketPrice: 2 }],
         },
@@ -67,13 +67,13 @@ describe('ClientComputedField - json data', function () {
       state: { totalSpentAmount: 55 },
       updates: [
         {
-          data_type: DataType.USER_ACTIVITY,
-          operation: Operation.INSERT,
+          data_type: 'USER_ACTIVITY',
+          operation: 'INSERT',
           data: { events: [{ basketPrice: 1 }] },
         },
         {
-          data_type: DataType.USER_ACTIVITY,
-          operation: Operation.INSERT,
+          data_type: 'USER_ACTIVITY',
+          operation: 'INSERT',
           data: { events: [{ basketPrice: 2 }, { basketPrice: 3 }] },
         },
       ],
@@ -96,13 +96,13 @@ describe('ClientComputedField - json data', function () {
       state: { totalSpentAmount: 55 },
       updates: [
         {
-          data_type: DataType.USER_ACTIVITY,
-          operation: Operation.INSERT,
+          data_type: 'USER_ACTIVITY',
+          operation: 'INSERT',
           data: { events: [{ basketPrice: 1 }] },
         },
         {
-          data_type: DataType.USER_ACTIVITY,
-          operation: Operation.INSERT,
+          data_type: 'USER_ACTIVITY',
+          operation: 'INSERT',
           data: { events: [{ basketPrice: 2 }, { basketPrice: 3 }] },
         },
       ],
@@ -121,13 +121,13 @@ describe('ClientComputedField - json data', function () {
       state: update1.data.state,
       updates: [
         {
-          data_type: DataType.USER_ACTIVITY,
-          operation: Operation.INSERT,
+          data_type: 'USER_ACTIVITY',
+          operation: 'INSERT',
           data: { events: [{ basketPrice: 2 }] },
         },
         {
-          data_type: DataType.USER_ACTIVITY,
-          operation: Operation.INSERT,
+          data_type: 'USER_ACTIVITY',
+          operation: 'INSERT',
           data: { events: [{ basketPrice: 4 }, { basketPrice: 6 }] },
         },
       ],

--- a/src/mediarithmics/plugins/computed-field/ComputedFieldBasePlugin.ts
+++ b/src/mediarithmics/plugins/computed-field/ComputedFieldBasePlugin.ts
@@ -25,21 +25,12 @@ export interface BuildResultPluginResponse<R> extends PluginResponse {
   };
 }
 
-export enum DataType {
-  USER_ACTIVITY,
-  USER_PROFILE,
-  COMPUTED_FIELD,
-}
-
-export enum Operation {
-  INSERT,
-  DELETE,
-  UPDATE,
-}
-
 export interface BaseUserActivity {}
 export interface BaseUserProfile {}
 export interface BaseComputedField {}
+
+export type DataType = 'USER_ACTIVITY' | 'USER_PROFILE' | 'COMPUTED_FIELD';
+export type Operation = 'INSERT' | 'DELETE' | 'UPDATE';
 
 export interface Update {
   data_type: DataType;
@@ -83,11 +74,11 @@ export abstract class ComputedFieldPlugin<
 
   private getUpdateMethod(state: State | null, update: Update): State | null {
     switch (update.data_type) {
-      case DataType.USER_ACTIVITY:
+      case 'USER_ACTIVITY':
         return this.onUpdateActivity(state, update.data as UserActivity);
-      case DataType.USER_PROFILE:
+      case 'USER_PROFILE':
         return this.onUpdateUserProfile(state, update.data as UserProfile, update.operation);
-      case DataType.COMPUTED_FIELD:
+      case 'COMPUTED_FIELD':
         return this.onUpdateComputedField(state, update.data as ComputedField);
       default:
         return state;


### PR DESCRIPTION
Deserialisation of enums is now working well as it infers the enum index instead of the value (ie: USER_ACTIVITY = 0, USER_PROFILE = 1)

This lead to a plugin always returning a null state when called by the platform.

Union types will work great instead.