### PR TITLE
MICS-21957 Add user profiles on user segment update

### DIFF
--- a/src/mediarithmics/api/plugin/audiencefeedconnector/AudienceFeedConnectorRequestInterface.ts
+++ b/src/mediarithmics/api/plugin/audiencefeedconnector/AudienceFeedConnectorRequestInterface.ts
@@ -1,5 +1,6 @@
 import { BatchUpdateContext } from '../../core/batchupdate/BatchUpdateInterface';
 import { UserIdentifierInfo } from '../../reference/UserIdentifierInterface';
+import { UserProfileInfo } from '../../reference/UserProfileInfo';
 
 export type UpdateType = 'UPSERT' | 'DELETE';
 
@@ -9,6 +10,7 @@ export interface UserSegmentUpdateRequest {
   datamart_id: string;
   segment_id: string;
   user_identifiers: UserIdentifierInfo[];
+  user_profiles: UserProfileInfo[];
   ts: number;
   operation: UpdateType;
 }

--- a/src/mediarithmics/api/reference/UserProfileInfo.ts
+++ b/src/mediarithmics/api/reference/UserProfileInfo.ts
@@ -1,0 +1,8 @@
+export interface UserProfileInfo {
+  $compartment_id: string;
+  $creation_ts: number;
+  $last_modified_ts: number;
+  $user_account_id?: string;
+  $expiration_ts?: number;
+  [key: string]: unknown;
+}

--- a/src/tests/AudienceFeedConnector.ts
+++ b/src/tests/AudienceFeedConnector.ts
@@ -209,6 +209,7 @@ describe.only('External Audience Feed API test', function () {
           mappings: [],
         } as core.UserAgentIdentifierInfo,
       ],
+      user_profiles: [],
     };
 
     const batchUpdateRequest: BatchUpdateRequest<AudienceFeedBatchContext, string> = {

--- a/src/tests/BatchedAudienceFeedConnector.ts
+++ b/src/tests/BatchedAudienceFeedConnector.ts
@@ -249,6 +249,7 @@ describe.only('External Audience Feed API test', function () {
           mappings: [],
         } as core.UserAgentIdentifierInfo,
       ],
+      user_profiles: [],
     };
 
     const batchUpdateRequest: BatchUpdateRequest<AudienceFeedBatchContext, string> = {


### PR DESCRIPTION
May be used for other information in the future but the main reason currently is to capture and share utiq fixed ids which are stored in profiles.