### PR TITLE
MICS-22017 rename dynamic properties & authentication status routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 # Unreleased
 
+- Add new optional route /v1/authentication_status_queries that takes ExternalSegmentAuthenticationStatusQueryRequest and responds ExternalSegmentAuthenticationStatusQueryResponse allowing plugins to check authentification status
+- Add new optional route /v1/dynamic_property_values_queries that take ExternalSegmentDynamicPropertyValuesQueryRequest and responds ExternalSegmentDynamicPropertyValuesQueryResponse allowing plugins to define dynamics properties values
+
 # v0.29.5 2025-03-18
 
 - Fix CVE-2024-52798

--- a/examples/audience-feed/src/ExampleAudienceFeed.ts
+++ b/examples/audience-feed/src/ExampleAudienceFeed.ts
@@ -152,19 +152,18 @@ export class ExampleAudienceFeed extends core.BatchedAudienceFeedConnectorBasePl
     }
   }
 
-  protected onAuthenticationStatus(
-    request: core.ExternalSegmentAuthenticationStatusRequest,
-  ): Promise<core.ExternalSegmentAuthenticationStatusResponse> {
+  protected onAuthenticationStatusQuery(
+    request: core.ExternalSegmentAuthenticationStatusQueryRequest,
+  ): Promise<core.ExternalSegmentAuthenticationStatusQueryResponse> {
     return Promise.resolve({ status: 'authenticated' });
   }
 
-
-  protected onDynamicPropertyValues(
-    request: core.ExternalSegmentDynamicPropertyValuesRequest
-  ): Promise<core.ExternalSegmentDynamicPropertyValuesResponse> {
+  protected onDynamicPropertyValuesQuery(
+    request: core.ExternalSegmentDynamicPropertyValuesQueryRequest,
+  ): Promise<core.ExternalSegmentDynamicPropertyValuesQueryResponse> {
     return Promise.resolve({
       status: 'ok',
-      data:[]
+      data: [],
     });
   }
 }

--- a/examples/audience-feed/src/tests/index.ts
+++ b/examples/audience-feed/src/tests/index.ts
@@ -203,7 +203,7 @@ describe.only('Test Audience Feed example', function () {
       });
   });
 
-  it('Test authentication_status and dynamic_property_values', (done) => {
+  it('Test authentication_status_queries', (done) => {
     const rpMockup: sinon.SinonStub = sinon.stub();
     runner = new core.TestingPluginRunner(plugin, rpMockup);
 
@@ -211,16 +211,16 @@ describe.only('Test Audience Feed example', function () {
     const user_id = '1000';
 
     request(runner.plugin.app)
-      .post('/v1/authentication_status')
-      .send({ datamart_id, user_id})
+      .post('/v1/authentication_status_queries')
+      .send({ datamart_id, user_id })
       .end((error, response) => {
-        const body: core.ExternalSegmentAuthenticationStatusResponse = JSON.parse(response.text);
+        const body: core.ExternalSegmentAuthenticationStatusQueryResponse = JSON.parse(response.text);
         expect(body.status).to.eq('authenticated');
         done();
       });
   });
 
-  it('Test authentication_status and dynamic_property_values', (done) => {
+  it('Test dynamic_property_values_query', (done) => {
     const rpMockup: sinon.SinonStub = sinon.stub();
     runner = new core.TestingPluginRunner(plugin, rpMockup);
 
@@ -228,10 +228,10 @@ describe.only('Test Audience Feed example', function () {
     const user_id = '1000';
 
     request(runner.plugin.app)
-      .post('/v1/dynamic_property_values')
-      .send({ datamart_id, user_id})
+      .post('/v1/dynamic_property_values_queries')
+      .send({ datamart_id, user_id })
       .end((error, response) => {
-        const body: core.ExternalSegmentDynamicPropertyValuesResponse = JSON.parse(response.text);
+        const body: core.ExternalSegmentDynamicPropertyValuesQueryResponse = JSON.parse(response.text);
         expect(body.status).to.eq('ok');
         expect(body.data).to.deep.eq([]);
         done();

--- a/src/mediarithmics/api/plugin/audiencefeedconnector/AudienceFeedConnectorPluginResponseInterface.ts
+++ b/src/mediarithmics/api/plugin/audiencefeedconnector/AudienceFeedConnectorPluginResponseInterface.ts
@@ -8,7 +8,7 @@ export declare type AudienceFeedConnectorAuthenticationStatus =
   | 'not_authenticated'
   | 'error'
   | 'not_implemented';
-export declare type AudienceFeedConnectorDynamicPropertyValuesStatus = 'ok' | 'error' | 'not_implemented';
+export declare type AudienceFeedConnectorDynamicPropertyValuesQueryStatus = 'ok' | 'error' | 'not_implemented';
 export type AudienceFeedConnectorContentType = 'text/csv' | 'application/json' | 'text/plain';
 
 export interface UserSegmentUpdatePluginResponse {
@@ -71,7 +71,7 @@ export interface ExternalSegmentTroubleshootResponse {
   data?: any;
 }
 
-export interface ExternalSegmentAuthenticationStatusResponse {
+export interface ExternalSegmentAuthenticationStatusQueryResponse {
   status: AudienceFeedConnectorAuthenticationStatus;
   message?: string;
   data?: {
@@ -80,8 +80,8 @@ export interface ExternalSegmentAuthenticationStatusResponse {
   };
 }
 
-export interface ExternalSegmentDynamicPropertyValuesResponse {
-  status: AudienceFeedConnectorDynamicPropertyValuesStatus;
+export interface ExternalSegmentDynamicPropertyValuesQueryResponse {
+  status: AudienceFeedConnectorDynamicPropertyValuesQueryStatus;
   message?: string;
   data?: {
     property_technical_name: string;

--- a/src/mediarithmics/api/plugin/audiencefeedconnector/AudienceFeedConnectorRequestInterface.ts
+++ b/src/mediarithmics/api/plugin/audiencefeedconnector/AudienceFeedConnectorRequestInterface.ts
@@ -59,14 +59,14 @@ export type TroubleshootActionFetchDestinationAudience = ExternalSegmentTroubles
 
 export type ExternalSegmentTroubleshootRequest = TroubleshootActionFetchDestinationAudience; // | TroubleshootActionWithArgs;
 
-export interface ExternalSegmentAuthenticationStatusRequest {
+export interface ExternalSegmentAuthenticationStatusQueryRequest {
   segment_id?: string;
   datamart_id: string;
   user_id: string;
   properties?: PluginProperty[];
 }
 
-export interface ExternalSegmentDynamicPropertyValuesRequest {
+export interface ExternalSegmentDynamicPropertyValuesQueryRequest {
   segment_id?: string;
   datamart_id: string;
   user_id: string;

--- a/src/mediarithmics/plugins/audience-feed-connector/AudienceFeedConnectorBasePlugin.ts
+++ b/src/mediarithmics/plugins/audience-feed-connector/AudienceFeedConnectorBasePlugin.ts
@@ -19,8 +19,8 @@ import {
   ExternalSegmentConnectionPluginResponse,
   ExternalSegmentCreationPluginResponse,
   ExternalSegmentTroubleshootResponse,
-  ExternalSegmentAuthenticationStatusResponse,
-  ExternalSegmentDynamicPropertyValuesResponse,
+  ExternalSegmentAuthenticationStatusQueryResponse,
+  ExternalSegmentDynamicPropertyValuesQueryResponse,
   MissingRealmError,
   UserSegmentUpdatePluginResponse,
 } from '../../api/plugin/audiencefeedconnector/AudienceFeedConnectorPluginResponseInterface';
@@ -30,8 +30,8 @@ import {
   ExternalSegmentCreationRequest,
   ExternalSegmentTroubleshootActions,
   ExternalSegmentTroubleshootRequest,
-  ExternalSegmentAuthenticationStatusRequest,
-  ExternalSegmentDynamicPropertyValuesRequest,
+  ExternalSegmentAuthenticationStatusQueryRequest,
+  ExternalSegmentDynamicPropertyValuesQueryRequest,
   UserSegmentUpdateRequest,
 } from '../../api/plugin/audiencefeedconnector/AudienceFeedConnectorRequestInterface';
 import { BasePlugin, PropertiesWrapper } from '../common';
@@ -57,8 +57,8 @@ abstract class GenericAudienceFeedConnectorBasePlugin<
     this.initExternalSegmentConnection();
     this.initUserSegmentUpdate();
     this.initTroubleshoot();
-    this.initAuthenticationStatus();
-    this.initDynamicPropertyValues();
+    this.initAuthenticationStatusQuery();
+    this.initDynamicPropertyValuesQuery();
   }
 
   async fetchAudienceSegment(feedId: string): Promise<AudienceSegmentResource> {
@@ -172,15 +172,15 @@ abstract class GenericAudienceFeedConnectorBasePlugin<
     return Promise.resolve({ status: 'not_implemented' });
   }
 
-  protected onAuthenticationStatus(
-    request: ExternalSegmentAuthenticationStatusRequest,
-  ): Promise<ExternalSegmentAuthenticationStatusResponse> {
+  protected onAuthenticationStatusQuery(
+    request: ExternalSegmentAuthenticationStatusQueryRequest,
+  ): Promise<ExternalSegmentAuthenticationStatusQueryResponse> {
     return Promise.resolve({ status: 'not_implemented' });
   }
 
-  protected onDynamicPropertyValues(
-    request: ExternalSegmentDynamicPropertyValuesRequest,
-  ): Promise<ExternalSegmentDynamicPropertyValuesResponse> {
+  protected onDynamicPropertyValuesQuery(
+    request: ExternalSegmentDynamicPropertyValuesQueryRequest,
+  ): Promise<ExternalSegmentDynamicPropertyValuesQueryResponse> {
     return Promise.resolve({ status: 'not_implemented' });
   }
 
@@ -421,14 +421,14 @@ abstract class GenericAudienceFeedConnectorBasePlugin<
     });
   }
 
-  private initAuthenticationStatus(): void {
+  private initAuthenticationStatusQuery(): void {
     this.app.post(
-      '/v1/authentication_status',
+      '/v1/authentication_status_queries',
       this.emptyBodyFilter,
       async (req: express.Request, res: express.Response) => {
         try {
-          const request = req.body as ExternalSegmentAuthenticationStatusRequest;
-          const response = await this.onAuthenticationStatus(request);
+          const request = req.body as ExternalSegmentAuthenticationStatusQueryRequest;
+          const response = await this.onAuthenticationStatusQuery(request);
           let statusCode: number;
           switch (response.status) {
             case 'authenticated':
@@ -444,26 +444,29 @@ abstract class GenericAudienceFeedConnectorBasePlugin<
             default:
               statusCode = 500;
           }
-          this.logger.debug(`Request: ${JSON.stringify(request)} - Authentication status returning: ${statusCode}`, {
-            response,
-          });
+          this.logger.debug(
+            `Request: ${JSON.stringify(request)} - Authentication status query returning: ${statusCode}`,
+            {
+              response,
+            },
+          );
           return res.status(statusCode).send(JSON.stringify(response));
         } catch (error) {
-          this.logger.error('Something bad happened on authentication status', error);
+          this.logger.error('Something bad happened on authentication status query', error);
           return res.status(500).send({ status: 'error', message: `${(error as Error).message}` });
         }
       },
     );
   }
 
-  private initDynamicPropertyValues(): void {
+  private initDynamicPropertyValuesQuery(): void {
     this.app.post(
-      '/v1/dynamic_property_values',
+      '/v1/dynamic_property_values_queries',
       this.emptyBodyFilter,
       async (req: express.Request, res: express.Response) => {
         try {
-          const request = req.body as ExternalSegmentDynamicPropertyValuesRequest;
-          const response = await this.onDynamicPropertyValues(request);
+          const request = req.body as ExternalSegmentDynamicPropertyValuesQueryRequest;
+          const response = await this.onDynamicPropertyValuesQuery(request);
           let statusCode: number;
           switch (response.status) {
             case 'ok':
@@ -478,12 +481,15 @@ abstract class GenericAudienceFeedConnectorBasePlugin<
             default:
               statusCode = 500;
           }
-          this.logger.debug(`Request: ${JSON.stringify(request)} - Dynamic property values returning: ${statusCode}`, {
-            response,
-          });
+          this.logger.debug(
+            `Request: ${JSON.stringify(request)} - Dynamic property values query returning: ${statusCode}`,
+            {
+              response,
+            },
+          );
           return res.status(statusCode).send(JSON.stringify(response));
         } catch (error) {
-          this.logger.error('Something bad happened on dynamic property values', error);
+          this.logger.error('Something bad happened on dynamic property values query', error);
           return res.status(500).send({ status: 'error', message: `${(error as Error).message}` });
         }
       },


### PR DESCRIPTION
rename /v1/dynamic_property_values route to /v1/dynamic_property_values_queries 
rename /v1/authentication_status route to /v1/authentication_status_queries 
for matching POST method semantic
add missing entries in changelog