### PR TITLE
MICS-22581 remove datamart_id from /authentication payload

### DIFF
--- a/examples/audience-feed/src/tests/index.ts
+++ b/examples/audience-feed/src/tests/index.ts
@@ -224,12 +224,11 @@ describe.only('Test Audience Feed example', function () {
     const rpMockup: sinon.SinonStub = sinon.stub();
     runner = new core.TestingPluginRunner(plugin, rpMockup);
 
-    const datamart_id = '1';
     const user_id = '1000';
 
     request(runner.plugin.app)
       .post('/v1/authentication')
-      .send({ datamart_id, user_id })
+      .send({ user_id })
       .end((error, response) => {
         const body: core.ExternalSegmentAuthenticationResponse = JSON.parse(response.text);
         expect(body.status).to.eq('ok');

--- a/src/mediarithmics/api/plugin/audiencefeedconnector/AudienceFeedConnectorRequestInterface.ts
+++ b/src/mediarithmics/api/plugin/audiencefeedconnector/AudienceFeedConnectorRequestInterface.ts
@@ -67,7 +67,6 @@ export interface ExternalSegmentAuthenticationStatusQueryRequest {
 }
 
 export interface ExternalSegmentAuthenticationRequest {
-  datamart_id: string;
   user_id: string;
   params?: Map<string, string>;
 }


### PR DESCRIPTION
remove datamart_id from /authentication route payload as we can't deduce this info from callback