### PR TITLE
MICS-23614 Add 'UPSERT' in CF Operation and deprecate usage of 'INSERT' & 'UPDATE'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # Unreleased
 
+- Add 'UPSERT' in Operation (for Computed field) and deprecate usage of 'INSERT' & 'UPDATE' (use 'UPSERT' instead)
+
 # 0.31.2
 
 - release the authentication feature, see the authentication-alpha pre-releases

--- a/examples/computed-field/src/tests/MyComputedField.test.ts
+++ b/examples/computed-field/src/tests/MyComputedField.test.ts
@@ -20,7 +20,7 @@ describe('ClientComputedField - json data', function () {
     const data = {
       update: {
         data_type: 'USER_ACTIVITY',
-        operation: 'INSERT',
+        operation: 'UPSERT',
         data: { events: [{ basketPrice: 1 }, { basketPrice: 2 }, { basketPrice: 3 }, { basketPrice: 2 }] },
       },
     };
@@ -43,7 +43,7 @@ describe('ClientComputedField - json data', function () {
       state: { totalSpentAmount: 10 },
       update: {
         data_type: 'USER_ACTIVITY',
-        operation: 'INSERT',
+        operation: 'UPSERT',
         data: {
           events: [{ basketPrice: 1 }, { basketPrice: 2 }, { basketPrice: 3 }, { basketPrice: 2 }],
         },
@@ -68,12 +68,12 @@ describe('ClientComputedField - json data', function () {
       updates: [
         {
           data_type: 'USER_ACTIVITY',
-          operation: 'INSERT',
+          operation: 'UPSERT',
           data: { events: [{ basketPrice: 1 }] },
         },
         {
           data_type: 'USER_ACTIVITY',
-          operation: 'INSERT',
+          operation: 'UPSERT',
           data: { events: [{ basketPrice: 2 }, { basketPrice: 3 }] },
         },
       ],
@@ -97,12 +97,12 @@ describe('ClientComputedField - json data', function () {
       updates: [
         {
           data_type: 'USER_ACTIVITY',
-          operation: 'INSERT',
+          operation: 'UPSERT',
           data: { events: [{ basketPrice: 1 }] },
         },
         {
           data_type: 'USER_ACTIVITY',
-          operation: 'INSERT',
+          operation: 'UPSERT',
           data: { events: [{ basketPrice: 2 }, { basketPrice: 3 }] },
         },
       ],
@@ -122,12 +122,12 @@ describe('ClientComputedField - json data', function () {
       updates: [
         {
           data_type: 'USER_ACTIVITY',
-          operation: 'INSERT',
+          operation: 'UPSERT',
           data: { events: [{ basketPrice: 2 }] },
         },
         {
           data_type: 'USER_ACTIVITY',
-          operation: 'INSERT',
+          operation: 'UPSERT',
           data: { events: [{ basketPrice: 4 }, { basketPrice: 6 }] },
         },
       ],

--- a/src/mediarithmics/plugins/computed-field/ComputedFieldBasePlugin.ts
+++ b/src/mediarithmics/plugins/computed-field/ComputedFieldBasePlugin.ts
@@ -30,7 +30,9 @@ export interface BaseUserProfile {}
 export interface BaseComputedField {}
 
 export type DataType = 'USER_ACTIVITY' | 'USER_PROFILE' | 'COMPUTED_FIELD';
-export type Operation = 'INSERT' | 'DELETE' | 'UPDATE';
+
+// only use UPSERT & DELETE, INSERT and UPDATE are deprecated
+export type Operation = 'INSERT' | 'DELETE' | 'UPDATE' | 'UPSERT';
 
 export interface Update {
   data_type: DataType;


### PR DESCRIPTION
Add 'UPSERT' in Operation (for Computed field) and deprecate usage of 'INSERT' & 'UPDATE' (use 'UPSERT' instead)