### PR TITLE
MICS-23634 remove deprecated 'INSERT' & 'UPDATE' from Computed Field Operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # Unreleased
 
+remove deprecated 'INSERT' & 'UPDATE' from Computed Field Operation
+
 # 0.32.0
 
 - Add 'UPSERT' in Operation (for Computed field) and deprecate usage of 'INSERT' & 'UPDATE' (use 'UPSERT' instead)

--- a/src/mediarithmics/plugins/computed-field/ComputedFieldBasePlugin.ts
+++ b/src/mediarithmics/plugins/computed-field/ComputedFieldBasePlugin.ts
@@ -31,8 +31,7 @@ export interface BaseComputedField {}
 
 export type DataType = 'USER_ACTIVITY' | 'USER_PROFILE' | 'COMPUTED_FIELD';
 
-// only use UPSERT & DELETE, INSERT and UPDATE are deprecated
-export type Operation = 'INSERT' | 'DELETE' | 'UPDATE' | 'UPSERT';
+export type Operation = 'UPSERT' | 'DELETE';
 
 export interface Update {
   data_type: DataType;


### PR DESCRIPTION
remove deprecated 'INSERT' & 'UPDATE' from Computed Field Operation use UPSERT instead