### PR TITLE
MICS-24405 Add check_destination_credentials route and fetchFeedDesti…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # Unreleased
 
+- Add `upsertFeedDestinationCredentials()` helper method
 - Add `POST /v1/test_authentication` route: fetches feed destination credentials and delegates to `onTestAuthentication()`
 - Add `fetchFeedDestinationCredentials()` helper method
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # Unreleased
 
+- Add `POST /v1/oauth_redirect_url` route: delegates to `onCreateOAuthRedirectUrl()` to generate an OAuth2 authorization URL
+- `onAuthentication()` now auto-upserts credentials when `feed_destination_id` is present in the request
+- Use `FeedDestinationCredentials` type in `ExternalSegmentAuthenticationResponse.credentials`
+- `onCreateOAuthRedirectUrl()` now throws by default if not overridden
 - Add `upsertFeedDestinationCredentials()` helper method
 - Add `POST /v1/test_authentication` route: fetches feed destination credentials and delegates to `onTestAuthentication()`
 - Add `fetchFeedDestinationCredentials()` helper method

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 # Unreleased
 
+- Add `POST /v1/test_authentication` route: fetches feed destination credentials and delegates to `onTestAuthentication()`
+- Add `fetchFeedDestinationCredentials()` helper method
+
 # 0.39.0 2026-04-27
 
 - `AudienceFeedConnectorDynamicPropertyValuesQueryStatus` now supports `'empty'` status in `onDynamicPropertyValuesQuery`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # Unreleased
 
+- Add optional `feed_destination_id` to `UserSegmentUpdateRequest`, `ExternalSegmentConnectionRequest`, `ExternalSegmentCreationRequest`, and `ExternalSegmentAuthenticationRequest`
 - Add `POST /v1/oauth_redirect_url` route: delegates to `onCreateOAuthRedirectUrl()` to generate an OAuth2 authorization URL
 - `onAuthentication()` now auto-upserts credentials when `feed_destination_id` is present in the request
 - Use `FeedDestinationCredentials` type in `ExternalSegmentAuthenticationResponse.credentials`

--- a/examples/audience-feed/src/ExampleAudienceFeed.ts
+++ b/examples/audience-feed/src/ExampleAudienceFeed.ts
@@ -158,13 +158,45 @@ export class ExampleAudienceFeed extends core.BatchedAudienceFeedConnectorBasePl
     return Promise.resolve({ status: 'authenticated' });
   }
 
+  protected onCreateOAuthRedirectUrl(
+    request: core.CreateOAuthRedirectUrlRequest,
+  ): Promise<core.CreateOAuthRedirectUrlPluginResponse> {
+    // Build your OAuth2 authorization URL here.
+    // The state parameter MUST contain feed_destination_id so the SDK can validate it.
+    const state = request.feed_destination_id;
+    const loginUrl = `https://accounts.example.com/oauth2/authorize?client_id=MY_CLIENT_ID&state=${state}&redirect_uri=MY_REDIRECT_URI&response_type=code`;
+    return Promise.resolve({ login_url: loginUrl });
+  }
+
   protected onAuthentication(
     request: core.ExternalSegmentAuthenticationRequest,
   ): Promise<core.ExternalSegmentAuthenticationResponse> {
-    if (request.params.creds == 'ok') {
+    if (request.feed_destination_id) {
+      // New OAuth2 flow: feed_destination_id is present, the SDK expects credentials
+      // in the response so it can upsert them to TenantCredentials automatically.
+      const refreshToken = 'MY_REFRESH_TOKEN'; // exchange request.params.code for a refresh token here
+      return Promise.resolve({
+        status: 'ok',
+        credentials: { scheme: 'OAUTH2', data: { refresh_token: refreshToken } },
+      });
+    }
+    // Legacy flow: no feed_destination_id, plugin manages credentials itself.
+    if (request.params && request.params.creds == 'ok') {
       return Promise.resolve({ status: 'ok' });
     }
     return Promise.resolve({ status: 'error' });
+  }
+
+  protected onTestAuthentication(
+    request: core.TestAuthenticationRequest,
+    credentials: core.FeedDestinationCredentials,
+  ): Promise<core.TestAuthenticationPluginResponse> {
+    // Use the credentials fetched from TenantCredentials to test the connection.
+    // credentials.credentials contains the data stored during onAuthentication (e.g. refresh_token).
+    if (credentials && credentials.credentials) {
+      return Promise.resolve({ status: 'ok' });
+    }
+    return Promise.resolve({ status: 'error', message: 'No credentials found' });
   }
 
   protected onLogout(request: core.ExternalSegmentLogoutRequest): Promise<core.ExternalSegmentLogoutResponse> {

--- a/src/mediarithmics/api/core/audiencesegment/FeedDestinationInterface.ts
+++ b/src/mediarithmics/api/core/audiencesegment/FeedDestinationInterface.ts
@@ -8,3 +8,8 @@ export interface FeedDestinationCredentials {
 }
 
 export type FeedDestinationCredentialsResponse = DataResponse<FeedDestinationCredentials>;
+
+export interface UpsertFeedDestinationCredentialsRequest {
+  feed_destination_id: string;
+  credentials: FeedDestinationCredentials;
+}

--- a/src/mediarithmics/api/core/audiencesegment/FeedDestinationInterface.ts
+++ b/src/mediarithmics/api/core/audiencesegment/FeedDestinationInterface.ts
@@ -1,0 +1,10 @@
+import { DataResponse } from '../common/Response';
+
+export type TenantCredentialsScheme = 'OAUTH2' | 'API_TOKEN' | 'LOGIN_PASSWORD';
+
+export interface FeedDestinationCredentials {
+  scheme: TenantCredentialsScheme;
+  credentials: Record<string, unknown>;
+}
+
+export type FeedDestinationCredentialsResponse = DataResponse<FeedDestinationCredentials>;

--- a/src/mediarithmics/api/plugin/audiencefeedconnector/AudienceFeedConnectorPluginResponseInterface.ts
+++ b/src/mediarithmics/api/plugin/audiencefeedconnector/AudienceFeedConnectorPluginResponseInterface.ts
@@ -85,6 +85,7 @@ export interface ExternalSegmentAuthenticationStatusQueryResponse {
 export interface ExternalSegmentAuthenticationResponse {
   status: AudienceFeedAuthenticationStatus;
   message?: string;
+  refresh_token?: string;
 }
 
 export interface ExternalSegmentLogoutResponse {
@@ -100,6 +101,10 @@ export interface ExternalSegmentDynamicPropertyValuesQueryResponse {
     enum: { label: string; value: string }[];
     [key: string]: any;
   }[];
+}
+
+export interface CreateOAuthRedirectUrlPluginResponse {
+  login_url: string;
 }
 
 export type TestAuthenticationStatus = 'ok' | 'error' | 'not_implemented';

--- a/src/mediarithmics/api/plugin/audiencefeedconnector/AudienceFeedConnectorPluginResponseInterface.ts
+++ b/src/mediarithmics/api/plugin/audiencefeedconnector/AudienceFeedConnectorPluginResponseInterface.ts
@@ -102,6 +102,13 @@ export interface ExternalSegmentDynamicPropertyValuesQueryResponse {
   }[];
 }
 
+export type TestAuthenticationStatus = 'ok' | 'error' | 'not_implemented';
+
+export interface TestAuthenticationPluginResponse {
+  status: TestAuthenticationStatus;
+  message?: string;
+}
+
 export interface AudienceFeedStatTag {
   key: string;
   value: string;

--- a/src/mediarithmics/api/plugin/audiencefeedconnector/AudienceFeedConnectorRequestInterface.ts
+++ b/src/mediarithmics/api/plugin/audiencefeedconnector/AudienceFeedConnectorRequestInterface.ts
@@ -10,6 +10,7 @@ export interface UserSegmentUpdateRequest {
   session_id: string;
   datamart_id: string;
   segment_id: string;
+  feed_destination_id?: string;
   user_identifiers: UserIdentifierInfo[];
   user_profiles: UserProfileInfo[];
   ts: number;
@@ -20,12 +21,14 @@ export interface ExternalSegmentConnectionRequest {
   feed_id: string;
   datamart_id: string;
   segment_id: string;
+  feed_destination_id?: string;
 }
 
 export interface ExternalSegmentCreationRequest {
   feed_id: string;
   datamart_id: string;
   segment_id: string;
+  feed_destination_id?: string;
 }
 
 export interface AudienceFeedBatchContext extends BatchUpdateContext {

--- a/src/mediarithmics/api/plugin/audiencefeedconnector/AudienceFeedConnectorRequestInterface.ts
+++ b/src/mediarithmics/api/plugin/audiencefeedconnector/AudienceFeedConnectorRequestInterface.ts
@@ -85,3 +85,7 @@ export interface ExternalSegmentDynamicPropertyValuesQueryRequest {
   user_id: string;
   properties?: PluginProperty[];
 }
+
+export interface TestAuthenticationRequest {
+  feed_destination_id: string;
+}

--- a/src/mediarithmics/api/plugin/audiencefeedconnector/AudienceFeedConnectorRequestInterface.ts
+++ b/src/mediarithmics/api/plugin/audiencefeedconnector/AudienceFeedConnectorRequestInterface.ts
@@ -71,6 +71,7 @@ export interface ExternalSegmentAuthenticationRequest {
   user_id: string;
   plugin_version_id: string;
   params?: { [key: string]: string };
+  feed_destination_id?: string;
 }
 
 export interface ExternalSegmentLogoutRequest {
@@ -88,4 +89,9 @@ export interface ExternalSegmentDynamicPropertyValuesQueryRequest {
 
 export interface TestAuthenticationRequest {
   feed_destination_id: string;
+}
+
+export interface CreateOAuthRedirectUrlRequest {
+  feed_destination_id: string;
+  plugin_version_id: string;
 }

--- a/src/mediarithmics/index.ts
+++ b/src/mediarithmics/index.ts
@@ -1,6 +1,7 @@
 export * from './api/core/bidoptimizer/BidOptimizerInterface';
 export * from './api/core/common/Response';
 export * from './api/core/audiencesegment/AudienceSegmentInterface';
+export * from './api/core/audiencesegment/FeedDestinationInterface';
 export * from './api/core/batchupdate/BatchUpdateInterface';
 export * from './api/core/datamart/Datamart';
 export * from './api/core/creative';

--- a/src/mediarithmics/plugins/audience-feed-connector/AudienceFeedConnectorBasePlugin.ts
+++ b/src/mediarithmics/plugins/audience-feed-connector/AudienceFeedConnectorBasePlugin.ts
@@ -12,6 +12,10 @@ import {
   AudienceSegmentResource,
   AudienceSegmentResourceResponse,
 } from '../../api/core/audiencesegment/AudienceSegmentInterface';
+import {
+  FeedDestinationCredentials,
+  FeedDestinationCredentialsResponse,
+} from '../../api/core/audiencesegment/FeedDestinationInterface';
 import { BatchUpdateHandler } from '../../api/core/batchupdate/BatchUpdateHandler';
 import { BatchUpdatePluginResponse, BatchUpdateRequest } from '../../api/core/batchupdate/BatchUpdateInterface';
 import {
@@ -21,6 +25,7 @@ import {
 } from '../../api/core/webdomain/UserAgentIdentifierRealmSelectionInterface';
 import {
   BatchedUserSegmentUpdatePluginResponse,
+  TestAuthenticationPluginResponse,
   ExternalSegmentAuthenticationResponse,
   ExternalSegmentAuthenticationStatusQueryResponse,
   ExternalSegmentConnectionPluginResponse,
@@ -33,6 +38,7 @@ import {
 } from '../../api/plugin/audiencefeedconnector/AudienceFeedConnectorPluginResponseInterface';
 import {
   AudienceFeedBatchContext,
+  TestAuthenticationRequest,
   ExternalSegmentAuthenticationRequest,
   ExternalSegmentAuthenticationStatusQueryRequest,
   ExternalSegmentConnectionRequest,
@@ -65,6 +71,7 @@ abstract class GenericAudienceFeedConnectorBasePlugin<
     this.initAuthentication();
     this.initLogoutQuery();
     this.initDynamicPropertyValuesQuery();
+    this.initTestAuthentication();
   }
 
   async fetchAudienceSegment(feedId: string): Promise<AudienceSegmentResource> {
@@ -115,6 +122,15 @@ abstract class GenericAudienceFeedConnectorBasePlugin<
       `${this.outboundPlatformUrl}/v1/audience_segment_external_feeds/${feedId}/properties`,
     );
     this.logger.debug(`Fetched External Feed Properties: ${feedId}`, { response });
+    return response.data;
+  }
+
+  async fetchFeedDestinationCredentials(feedDestinationId: string): Promise<FeedDestinationCredentials> {
+    const response = await super.requestGatewayHelper<FeedDestinationCredentialsResponse>(
+      'GET',
+      `${this.outboundPlatformUrl}/v1/feed_destinations/${feedDestinationId}/credentials`,
+    );
+    this.logger.debug(`Fetched credentials for feed destination: ${feedDestinationId}`);
     return response.data;
   }
 
@@ -197,6 +213,13 @@ abstract class GenericAudienceFeedConnectorBasePlugin<
   protected onDynamicPropertyValuesQuery(
     request: ExternalSegmentDynamicPropertyValuesQueryRequest,
   ): Promise<ExternalSegmentDynamicPropertyValuesQueryResponse> {
+    return Promise.resolve({ status: 'not_implemented' });
+  }
+
+  protected onTestAuthentication(
+    request: TestAuthenticationRequest,
+    credentials: FeedDestinationCredentials,
+  ): Promise<TestAuthenticationPluginResponse> {
     return Promise.resolve({ status: 'not_implemented' });
   }
 
@@ -533,6 +556,62 @@ abstract class GenericAudienceFeedConnectorBasePlugin<
         return res.status(500).send({ status: 'error', message: `${(error as Error).message}` });
       }
     });
+  }
+
+  private initTestAuthentication(): void {
+    this.app.post(
+      '/v1/test_authentication',
+      this.emptyBodyFilter,
+      async (req: express.Request, res: express.Response) => {
+        try {
+          this.logger.debug('POST /v1/test_authentication', { request: req.body });
+
+          if (!this.httpIsReady()) {
+            throw new Error('Plugin not initialized');
+          }
+
+          const request = req.body as TestAuthenticationRequest;
+
+          let credentials: FeedDestinationCredentials;
+          try {
+            credentials = await this.fetchFeedDestinationCredentials(request.feed_destination_id);
+          } catch {
+            const response: TestAuthenticationPluginResponse = {
+              status: 'not_implemented',
+              message: 'Could not fetch feed destination credentials',
+            };
+            return res.status(400).send(JSON.stringify(response));
+          }
+
+          const response = await this.onTestAuthentication(request, credentials);
+
+          let statusCode: number;
+          switch (response.status) {
+            case 'ok':
+              statusCode = 200;
+              break;
+            case 'error':
+              statusCode = 500;
+              break;
+            case 'not_implemented':
+              statusCode = 400;
+              break;
+            default:
+              statusCode = 500;
+          }
+
+          this.logger.debug(
+            `FeedDestinationId: ${request.feed_destination_id} - Check destination credentials returning: ${statusCode}`,
+            { response },
+          );
+
+          return res.status(statusCode).send(JSON.stringify(response));
+        } catch (error) {
+          this.logger.error('Something bad happened on check destination credentials', error);
+          return res.status(500).send({ status: 'error', message: `${(error as Error).message}` });
+        }
+      },
+    );
   }
 
   private initDynamicPropertyValuesQuery(): void {

--- a/src/mediarithmics/plugins/audience-feed-connector/AudienceFeedConnectorBasePlugin.ts
+++ b/src/mediarithmics/plugins/audience-feed-connector/AudienceFeedConnectorBasePlugin.ts
@@ -26,6 +26,7 @@ import {
 } from '../../api/core/webdomain/UserAgentIdentifierRealmSelectionInterface';
 import {
   BatchedUserSegmentUpdatePluginResponse,
+  CreateOAuthRedirectUrlPluginResponse,
   TestAuthenticationPluginResponse,
   ExternalSegmentAuthenticationResponse,
   ExternalSegmentAuthenticationStatusQueryResponse,
@@ -39,6 +40,7 @@ import {
 } from '../../api/plugin/audiencefeedconnector/AudienceFeedConnectorPluginResponseInterface';
 import {
   AudienceFeedBatchContext,
+  CreateOAuthRedirectUrlRequest,
   TestAuthenticationRequest,
   ExternalSegmentAuthenticationRequest,
   ExternalSegmentAuthenticationStatusQueryRequest,
@@ -73,6 +75,7 @@ abstract class GenericAudienceFeedConnectorBasePlugin<
     this.initLogoutQuery();
     this.initDynamicPropertyValuesQuery();
     this.initTestAuthentication();
+    this.initCreateOAuthRedirectUrl();
   }
 
   async fetchAudienceSegment(feedId: string): Promise<AudienceSegmentResource> {
@@ -237,6 +240,11 @@ abstract class GenericAudienceFeedConnectorBasePlugin<
     return Promise.resolve({ status: 'not_implemented' });
   }
 
+  protected onCreateOAuthRedirectUrl(
+    request: CreateOAuthRedirectUrlRequest,
+  ): Promise<CreateOAuthRedirectUrlPluginResponse> {
+    return Promise.reject(new Error('onCreateOAuthRedirectUrl is not implemented'));
+  }
 
   protected async getInstanceContext(
     feedId: string,
@@ -256,7 +264,7 @@ abstract class GenericAudienceFeedConnectorBasePlugin<
     return this.pluginCache.get(feedId) as Promise<AudienceFeedConnectorBaseInstanceContext>;
   }
 
-  protected emptyBodyFilter(req: express.Request, res: express.Response, next: express.NextFunction) {
+  protected emptyBodyFilter = (req: express.Request, res: express.Response, next: express.NextFunction) => {
     if (!req.body || _.isEmpty(req.body)) {
       const msg = {
         error: 'Missing request body',
@@ -519,6 +527,22 @@ abstract class GenericAudienceFeedConnectorBasePlugin<
         const request = req.body as ExternalSegmentAuthenticationRequest;
         const response = await this.onAuthentication(request);
 
+        if (request.feed_destination_id && response.status === 'ok') {
+          if (!response.refresh_token) {
+            throw new Error(
+              `Plugin must return a refresh_token when feed_destination_id is present`,
+            );
+          }
+          await this.upsertFeedDestinationCredentials(request.feed_destination_id, {
+            scheme: 'OAUTH2',
+            credentials: { refresh_token: response.refresh_token },
+          });
+          this.logger.debug(
+            `FeedDestinationId: ${request.feed_destination_id} - Credentials upserted after authentication`,
+          );
+        }
+
+        const { refresh_token: _refresh_token, ...responseWithoutCredentials } = response;
         let statusCode: number;
         switch (response.status) {
           case 'ok':
@@ -534,9 +558,9 @@ abstract class GenericAudienceFeedConnectorBasePlugin<
             statusCode = 500;
         }
         this.logger.debug(`Request: ${JSON.stringify(req.body)} - Authentication returning: ${statusCode}`, {
-          response,
+          response: responseWithoutCredentials,
         });
-        return res.status(statusCode).send(JSON.stringify(response));
+        return res.status(statusCode).send(JSON.stringify(responseWithoutCredentials));
       } catch (error) {
         this.logger.error('Something bad happened on authentication', error);
         return res.status(500).send({ status: 'error', message: `${(error as Error).message}` });
@@ -593,10 +617,10 @@ abstract class GenericAudienceFeedConnectorBasePlugin<
             credentials = await this.fetchFeedDestinationCredentials(request.feed_destination_id);
           } catch {
             const response: TestAuthenticationPluginResponse = {
-              status: 'not_implemented',
+              status: 'error',
               message: 'Could not fetch feed destination credentials',
             };
-            return res.status(400).send(JSON.stringify(response));
+            return res.status(500).send(JSON.stringify(response));
           }
 
           const response = await this.onTestAuthentication(request, credentials);
@@ -624,6 +648,45 @@ abstract class GenericAudienceFeedConnectorBasePlugin<
           return res.status(statusCode).send(JSON.stringify(response));
         } catch (error) {
           this.logger.error('Something bad happened on check destination credentials', error);
+          return res.status(500).send({ status: 'error', message: `${(error as Error).message}` });
+        }
+      },
+    );
+  }
+
+  private initCreateOAuthRedirectUrl(): void {
+    this.app.post(
+      '/v1/oauth_redirect_url',
+      this.emptyBodyFilter,
+      async (req: express.Request, res: express.Response) => {
+        try {
+          this.logger.debug('POST /v1/oauth_redirect_url', { request: req.body });
+
+          if (!this.httpIsReady()) {
+            throw new Error('Plugin not initialized');
+          }
+
+          const request = req.body as CreateOAuthRedirectUrlRequest;
+          if (!request.feed_destination_id) {
+            throw new Error('feed_destination_id is required');
+          }
+          const response = await this.onCreateOAuthRedirectUrl(request);
+
+          const url = new URL(response.login_url);
+          const state = url.searchParams.get('state');
+          if (!state || !state.includes(request.feed_destination_id)) {
+            throw new Error(
+              `login_url state must contain feed_destination_id: ${request.feed_destination_id}`,
+            );
+          }
+
+          this.logger.debug(
+            `FeedDestinationId: ${request.feed_destination_id} - OAuth redirect URL generated`,
+          );
+
+          return res.status(200).send(JSON.stringify(response));
+        } catch (error) {
+          this.logger.error('Something bad happened on create OAuth redirect URL', error);
           return res.status(500).send({ status: 'error', message: `${(error as Error).message}` });
         }
       },

--- a/src/mediarithmics/plugins/audience-feed-connector/AudienceFeedConnectorBasePlugin.ts
+++ b/src/mediarithmics/plugins/audience-feed-connector/AudienceFeedConnectorBasePlugin.ts
@@ -15,6 +15,7 @@ import {
 import {
   FeedDestinationCredentials,
   FeedDestinationCredentialsResponse,
+  UpsertFeedDestinationCredentialsRequest,
 } from '../../api/core/audiencesegment/FeedDestinationInterface';
 import { BatchUpdateHandler } from '../../api/core/batchupdate/BatchUpdateHandler';
 import { BatchUpdatePluginResponse, BatchUpdateRequest } from '../../api/core/batchupdate/BatchUpdateInterface';
@@ -134,6 +135,19 @@ abstract class GenericAudienceFeedConnectorBasePlugin<
     return response.data;
   }
 
+  async upsertFeedDestinationCredentials(
+    feedDestinationId: string,
+    credentials: FeedDestinationCredentials,
+  ): Promise<void> {
+    const body: UpsertFeedDestinationCredentialsRequest = { feed_destination_id: feedDestinationId, credentials };
+    await super.requestGatewayHelper<void>(
+      'POST',
+      `${this.outboundPlatformUrl}/v1/feed_destinations/${feedDestinationId}/credentials`,
+      body,
+    );
+    this.logger.debug(`Upserted credentials for feed destination: ${feedDestinationId}`);
+  }
+
   async createAudienceFeedProperties(feedId: string, property: PluginProperty): Promise<PluginProperty[]> {
     const response = await super.requestGatewayHelper<PluginPropertyResponse>(
       'POST',
@@ -222,6 +236,7 @@ abstract class GenericAudienceFeedConnectorBasePlugin<
   ): Promise<TestAuthenticationPluginResponse> {
     return Promise.resolve({ status: 'not_implemented' });
   }
+
 
   protected async getInstanceContext(
     feedId: string,
@@ -503,6 +518,7 @@ abstract class GenericAudienceFeedConnectorBasePlugin<
       try {
         const request = req.body as ExternalSegmentAuthenticationRequest;
         const response = await this.onAuthentication(request);
+
         let statusCode: number;
         switch (response.status) {
           case 'ok':

--- a/src/mediarithmics/plugins/audience-feed-connector/AudienceFeedConnectorBasePlugin.ts
+++ b/src/mediarithmics/plugins/audience-feed-connector/AudienceFeedConnectorBasePlugin.ts
@@ -15,7 +15,6 @@ import {
 import {
   FeedDestinationCredentials,
   FeedDestinationCredentialsResponse,
-  UpsertFeedDestinationCredentialsRequest,
 } from '../../api/core/audiencesegment/FeedDestinationInterface';
 import { BatchUpdateHandler } from '../../api/core/batchupdate/BatchUpdateHandler';
 import { BatchUpdatePluginResponse, BatchUpdateRequest } from '../../api/core/batchupdate/BatchUpdateInterface';
@@ -142,7 +141,7 @@ abstract class GenericAudienceFeedConnectorBasePlugin<
     feedDestinationId: string,
     credentials: FeedDestinationCredentials,
   ): Promise<void> {
-    const body: UpsertFeedDestinationCredentialsRequest = { feed_destination_id: feedDestinationId, credentials };
+    const body = { scheme: credentials.scheme, credentials: credentials.credentials };
     await super.requestGatewayHelper<void>(
       'POST',
       `${this.outboundPlatformUrl}/v1/feed_destinations/${feedDestinationId}/credentials`,
@@ -673,10 +672,10 @@ abstract class GenericAudienceFeedConnectorBasePlugin<
           const response = await this.onCreateOAuthRedirectUrl(request);
 
           const url = new URL(response.login_url);
-          const state = url.searchParams.get('state');
-          if (!state || !state.includes(request.feed_destination_id)) {
+          const feedDestinationIdParam = url.searchParams.get('feed_destination_id');
+          if (feedDestinationIdParam !== request.feed_destination_id) {
             throw new Error(
-              `login_url state must contain feed_destination_id: ${request.feed_destination_id}`,
+              `login_url must contain feed_destination_id as query param: ${request.feed_destination_id}`,
             );
           }
 

--- a/src/tests/AudienceFeedConnector.ts
+++ b/src/tests/AudienceFeedConnector.ts
@@ -199,7 +199,7 @@ class MyFakeAudienceFeedConnectorWithOAuth extends core.AudienceFeedConnectorBas
     request: CreateOAuthRedirectUrlRequest,
   ): Promise<CreateOAuthRedirectUrlPluginResponse> {
     return Promise.resolve({
-      login_url: `https://accounts.google.com/o/oauth2/v2/auth?state=${request.feed_destination_id}&client_id=my-client`,
+      login_url: `https://accounts.google.com/o/oauth2/v2/auth?feed_destination_id=${request.feed_destination_id}&client_id=my-client`,
     });
   }
 
@@ -239,7 +239,7 @@ class MyFakeAudienceFeedConnectorWithBadOAuthUrl extends core.AudienceFeedConnec
     request: CreateOAuthRedirectUrlRequest,
   ): Promise<CreateOAuthRedirectUrlPluginResponse> {
     return Promise.resolve({
-      login_url: `https://accounts.google.com/o/oauth2/v2/auth?state=other_param&client_id=my-client`,
+      login_url: `https://accounts.google.com/o/oauth2/v2/auth?state=other_param&client_id=my-client&feed_destination_id=wrong_id`,
     });
   }
 }
@@ -274,7 +274,7 @@ class MyFakeAudienceFeedConnectorWithOAuthNoCredentials extends core.AudienceFee
 }
 
 describe('createOAuthRedirectUrl', function () {
-  it('should return 200 with login_url when feed_destination_id is in state', function (done) {
+  it('should return 200 with login_url when feed_destination_id is a query param', function (done) {
     const rpMockup: sinon.SinonStub = sinon.stub().returns(Promise.resolve({}));
     const plugin = new MyFakeAudienceFeedConnectorWithOAuth(false);
     const runner = new core.TestingPluginRunner(plugin, rpMockup);
@@ -291,7 +291,7 @@ describe('createOAuthRedirectUrl', function () {
       });
   });
 
-  it('should return 500 when login_url state does not contain feed_destination_id', function (done) {
+  it('should return 500 when login_url feed_destination_id query param does not match', function (done) {
     const rpMockup: sinon.SinonStub = sinon.stub().returns(Promise.resolve({}));
     const plugin = new MyFakeAudienceFeedConnectorWithBadOAuthUrl(false);
     const runner = new core.TestingPluginRunner(plugin, rpMockup);

--- a/src/tests/AudienceFeedConnector.ts
+++ b/src/tests/AudienceFeedConnector.ts
@@ -10,6 +10,11 @@ import request from 'supertest';
 import { core } from '../';
 import { AudienceFeedBatchContext, UserSegmentUpdatePluginFileDeliveryResponseData } from '../mediarithmics';
 import { BatchUpdateRequest } from '../mediarithmics/api/core/batchupdate/BatchUpdateInterface';
+import {
+  TestAuthenticationPluginResponse,
+  TestAuthenticationRequest,
+  FeedDestinationCredentials,
+} from '../mediarithmics';
 
 const PLUGIN_AUTHENTICATION_TOKEN = 'Manny';
 const PLUGIN_WORKER_ID = 'Calavera';
@@ -61,6 +66,105 @@ const rpMockup: sinon.SinonStub = sinon.stub().returns(
     resolve('Yolo');
   }),
 );
+
+class MyFakeAudienceFeedConnectorWithCredentialsCheck extends core.AudienceFeedConnectorBasePlugin {
+  protected onExternalSegmentCreation(
+    request: core.ExternalSegmentCreationRequest,
+    instanceContext: core.AudienceFeedConnectorBaseInstanceContext,
+  ): Promise<core.ExternalSegmentCreationPluginResponse> {
+    return Promise.resolve({ status: 'ok' });
+  }
+
+  protected onExternalSegmentConnection(
+    request: core.ExternalSegmentConnectionRequest,
+    instanceContext: core.AudienceFeedConnectorBaseInstanceContext,
+  ): Promise<core.ExternalSegmentConnectionPluginResponse> {
+    return Promise.resolve({ status: 'ok' });
+  }
+
+  protected onUserSegmentUpdate(
+    request: core.UserSegmentUpdateRequest,
+    instanceContext: core.AudienceFeedConnectorBaseInstanceContext,
+  ): Promise<core.UserSegmentUpdatePluginResponse> {
+    return Promise.resolve({ status: 'ok' });
+  }
+
+  protected onTestAuthentication(
+    request: TestAuthenticationRequest,
+    credentials: FeedDestinationCredentials,
+  ): Promise<TestAuthenticationPluginResponse> {
+    return Promise.resolve({ status: 'ok' });
+  }
+}
+
+describe('Check Destination Credentials', function () {
+  it('should return not_implemented (400) when no credentials are stored', function (done) {
+    const rpMockup: sinon.SinonStub = sinon.stub().rejects(new Error('Not Found'));
+    const plugin = new MyFakeAudienceFeedConnectorWithCredentialsCheck(false);
+    const runner = new core.TestingPluginRunner(plugin, rpMockup);
+
+    const checkRequest: TestAuthenticationRequest = { feed_destination_id: '42' };
+
+    void request(runner.plugin.app)
+      .post('/v1/test_authentication')
+      .send(checkRequest)
+      .end(function (err, res) {
+        expect(res.status).to.equal(400);
+        expect(JSON.parse(res.text).status).to.be.eq('not_implemented');
+        expect(JSON.parse(res.text).message).to.be.eq('Could not fetch feed destination credentials');
+        done();
+      });
+  });
+
+  it('should call onTestAuthentication with fetched credentials and return ok', function (done) {
+    const credentials: FeedDestinationCredentials = {
+      scheme: 'API_TOKEN',
+      credentials: { token: 'my-secret-token' },
+    };
+
+    const rpMockup: sinon.SinonStub = sinon.stub().returns(Promise.resolve({ status: 'ok', data: credentials }));
+
+    const plugin = new MyFakeAudienceFeedConnectorWithCredentialsCheck(false);
+    const runner = new core.TestingPluginRunner(plugin, rpMockup);
+
+    const checkRequest: TestAuthenticationRequest = { feed_destination_id: '42' };
+
+    void request(runner.plugin.app)
+      .post('/v1/test_authentication')
+      .send(checkRequest)
+      .end(function (err, res) {
+        expect(res.status).to.equal(200);
+        expect(JSON.parse(res.text).status).to.be.eq('ok');
+        expect(rpMockup.args[0][0].uri).to.be.eq(
+          `${runner.plugin.outboundPlatformUrl}/v1/feed_destinations/42/credentials`,
+        );
+        done();
+      });
+  });
+
+  it('should return not_implemented (400) when onTestAuthentication is not overridden', function (done) {
+    const credentials: FeedDestinationCredentials = {
+      scheme: 'API_TOKEN',
+      credentials: { token: 'my-secret-token' },
+    };
+
+    const rpMockup: sinon.SinonStub = sinon.stub().returns(Promise.resolve({ status: 'ok', data: credentials }));
+
+    const plugin = new MyFakeAudienceFeedConnector(false);
+    const runner = new core.TestingPluginRunner(plugin, rpMockup);
+
+    const checkRequest: TestAuthenticationRequest = { feed_destination_id: '42' };
+
+    void request(runner.plugin.app)
+      .post('/v1/test_authentication')
+      .send(checkRequest)
+      .end(function (err, res) {
+        expect(res.status).to.equal(400);
+        expect(JSON.parse(res.text).status).to.be.eq('not_implemented');
+        done();
+      });
+  });
+});
 
 describe('Fetch Audience Feed Gateway API', () => {
   // All the magic is here

--- a/src/tests/AudienceFeedConnector.ts
+++ b/src/tests/AudienceFeedConnector.ts
@@ -11,9 +11,12 @@ import { core } from '../';
 import { AudienceFeedBatchContext, UserSegmentUpdatePluginFileDeliveryResponseData } from '../mediarithmics';
 import { BatchUpdateRequest } from '../mediarithmics/api/core/batchupdate/BatchUpdateInterface';
 import {
+  CreateOAuthRedirectUrlPluginResponse,
   TestAuthenticationPluginResponse,
 } from '../mediarithmics/api/plugin/audiencefeedconnector/AudienceFeedConnectorPluginResponseInterface';
 import {
+  CreateOAuthRedirectUrlRequest,
+  ExternalSegmentAuthenticationRequest,
   TestAuthenticationRequest,
 } from '../mediarithmics/api/plugin/audiencefeedconnector/AudienceFeedConnectorRequestInterface';
 import {
@@ -102,7 +105,7 @@ class MyFakeAudienceFeedConnectorWithCredentialsCheck extends core.AudienceFeedC
 }
 
 describe('Check Destination Credentials', function () {
-  it('should return not_implemented (400) when no credentials are stored', function (done) {
+  it('should return error (500) when no credentials are stored', function (done) {
     const rpMockup: sinon.SinonStub = sinon.stub().rejects(new Error('Not Found'));
     const plugin = new MyFakeAudienceFeedConnectorWithCredentialsCheck(false);
     const runner = new core.TestingPluginRunner(plugin, rpMockup);
@@ -113,8 +116,8 @@ describe('Check Destination Credentials', function () {
       .post('/v1/test_authentication')
       .send(checkRequest)
       .end(function (err, res) {
-        expect(res.status).to.equal(400);
-        expect(JSON.parse(res.text).status).to.be.eq('not_implemented');
+        expect(res.status).to.equal(500);
+        expect(JSON.parse(res.text).status).to.be.eq('error');
         expect(JSON.parse(res.text).message).to.be.eq('Could not fetch feed destination credentials');
         done();
       });
@@ -165,6 +168,228 @@ describe('Check Destination Credentials', function () {
       .end(function (err, res) {
         expect(res.status).to.equal(400);
         expect(JSON.parse(res.text).status).to.be.eq('not_implemented');
+        done();
+      });
+  });
+});
+
+class MyFakeAudienceFeedConnectorWithOAuth extends core.AudienceFeedConnectorBasePlugin {
+  protected onExternalSegmentCreation(
+    request: core.ExternalSegmentCreationRequest,
+    instanceContext: core.AudienceFeedConnectorBaseInstanceContext,
+  ): Promise<core.ExternalSegmentCreationPluginResponse> {
+    return Promise.resolve({ status: 'ok' });
+  }
+
+  protected onExternalSegmentConnection(
+    request: core.ExternalSegmentConnectionRequest,
+    instanceContext: core.AudienceFeedConnectorBaseInstanceContext,
+  ): Promise<core.ExternalSegmentConnectionPluginResponse> {
+    return Promise.resolve({ status: 'ok' });
+  }
+
+  protected onUserSegmentUpdate(
+    request: core.UserSegmentUpdateRequest,
+    instanceContext: core.AudienceFeedConnectorBaseInstanceContext,
+  ): Promise<core.UserSegmentUpdatePluginResponse> {
+    return Promise.resolve({ status: 'ok' });
+  }
+
+  protected onCreateOAuthRedirectUrl(
+    request: CreateOAuthRedirectUrlRequest,
+  ): Promise<CreateOAuthRedirectUrlPluginResponse> {
+    return Promise.resolve({
+      login_url: `https://accounts.google.com/o/oauth2/v2/auth?state=${request.feed_destination_id}&client_id=my-client`,
+    });
+  }
+
+  protected onAuthentication(
+    request: ExternalSegmentAuthenticationRequest,
+  ): Promise<core.ExternalSegmentAuthenticationResponse> {
+    return Promise.resolve({
+      status: 'ok',
+      refresh_token: 'my-refresh-token',
+    });
+  }
+}
+
+class MyFakeAudienceFeedConnectorWithBadOAuthUrl extends core.AudienceFeedConnectorBasePlugin {
+  protected onExternalSegmentCreation(
+    request: core.ExternalSegmentCreationRequest,
+    instanceContext: core.AudienceFeedConnectorBaseInstanceContext,
+  ): Promise<core.ExternalSegmentCreationPluginResponse> {
+    return Promise.resolve({ status: 'ok' });
+  }
+
+  protected onExternalSegmentConnection(
+    request: core.ExternalSegmentConnectionRequest,
+    instanceContext: core.AudienceFeedConnectorBaseInstanceContext,
+  ): Promise<core.ExternalSegmentConnectionPluginResponse> {
+    return Promise.resolve({ status: 'ok' });
+  }
+
+  protected onUserSegmentUpdate(
+    request: core.UserSegmentUpdateRequest,
+    instanceContext: core.AudienceFeedConnectorBaseInstanceContext,
+  ): Promise<core.UserSegmentUpdatePluginResponse> {
+    return Promise.resolve({ status: 'ok' });
+  }
+
+  protected onCreateOAuthRedirectUrl(
+    request: CreateOAuthRedirectUrlRequest,
+  ): Promise<CreateOAuthRedirectUrlPluginResponse> {
+    return Promise.resolve({
+      login_url: `https://accounts.google.com/o/oauth2/v2/auth?state=other_param&client_id=my-client`,
+    });
+  }
+}
+
+class MyFakeAudienceFeedConnectorWithOAuthNoCredentials extends core.AudienceFeedConnectorBasePlugin {
+  protected onExternalSegmentCreation(
+    request: core.ExternalSegmentCreationRequest,
+    instanceContext: core.AudienceFeedConnectorBaseInstanceContext,
+  ): Promise<core.ExternalSegmentCreationPluginResponse> {
+    return Promise.resolve({ status: 'ok' });
+  }
+
+  protected onExternalSegmentConnection(
+    request: core.ExternalSegmentConnectionRequest,
+    instanceContext: core.AudienceFeedConnectorBaseInstanceContext,
+  ): Promise<core.ExternalSegmentConnectionPluginResponse> {
+    return Promise.resolve({ status: 'ok' });
+  }
+
+  protected onUserSegmentUpdate(
+    request: core.UserSegmentUpdateRequest,
+    instanceContext: core.AudienceFeedConnectorBaseInstanceContext,
+  ): Promise<core.UserSegmentUpdatePluginResponse> {
+    return Promise.resolve({ status: 'ok' });
+  }
+
+  protected onAuthentication(
+    request: ExternalSegmentAuthenticationRequest,
+  ): Promise<core.ExternalSegmentAuthenticationResponse> {
+    return Promise.resolve({ status: 'ok' });
+  }
+}
+
+describe('createOAuthRedirectUrl', function () {
+  it('should return 200 with login_url when feed_destination_id is in state', function (done) {
+    const rpMockup: sinon.SinonStub = sinon.stub().returns(Promise.resolve({}));
+    const plugin = new MyFakeAudienceFeedConnectorWithOAuth(false);
+    const runner = new core.TestingPluginRunner(plugin, rpMockup);
+
+    const req: CreateOAuthRedirectUrlRequest = { feed_destination_id: '42', plugin_version_id: '99' };
+
+    void request(runner.plugin.app)
+      .post('/v1/oauth_redirect_url')
+      .send(req)
+      .end(function (err, res) {
+        expect(res.status).to.equal(200);
+        expect(JSON.parse(res.text).login_url).to.include('42');
+        done();
+      });
+  });
+
+  it('should return 500 when login_url state does not contain feed_destination_id', function (done) {
+    const rpMockup: sinon.SinonStub = sinon.stub().returns(Promise.resolve({}));
+    const plugin = new MyFakeAudienceFeedConnectorWithBadOAuthUrl(false);
+    const runner = new core.TestingPluginRunner(plugin, rpMockup);
+
+    const req: CreateOAuthRedirectUrlRequest = { feed_destination_id: '42', plugin_version_id: '99' };
+
+    void request(runner.plugin.app)
+      .post('/v1/oauth_redirect_url')
+      .send(req)
+      .end(function (err, res) {
+        expect(res.status).to.equal(500);
+        expect(JSON.parse(res.text).message).to.include('feed_destination_id');
+        done();
+      });
+  });
+
+  it('should return 500 when feed_destination_id is missing from request', function (done) {
+    const rpMockup: sinon.SinonStub = sinon.stub().returns(Promise.resolve({}));
+    const plugin = new MyFakeAudienceFeedConnectorWithOAuth(false);
+    const runner = new core.TestingPluginRunner(plugin, rpMockup);
+
+    void request(runner.plugin.app)
+      .post('/v1/oauth_redirect_url')
+      .send({ plugin_version_id: '99' })
+      .end(function (err, res) {
+        expect(res.status).to.equal(500);
+        expect(JSON.parse(res.text).message).to.include('feed_destination_id');
+        done();
+      });
+  });
+});
+
+describe('authenticate wrapper', function () {
+  it('should call upsertFeedDestinationCredentials and strip credentials when feed_destination_id present', function (done) {
+    const rpMockup: sinon.SinonStub = sinon.stub().returns(Promise.resolve({}));
+    const plugin = new MyFakeAudienceFeedConnectorWithOAuth(false);
+    const runner = new core.TestingPluginRunner(plugin, rpMockup);
+
+    const req: ExternalSegmentAuthenticationRequest = {
+      user_id: 'user1',
+      plugin_version_id: '99',
+      feed_destination_id: '42',
+      params: { code: 'auth-code', state: '42' },
+    };
+
+    void request(runner.plugin.app)
+      .post('/v1/authentication')
+      .send(req)
+      .end(function (err, res) {
+        expect(res.status).to.equal(200);
+        expect(JSON.parse(res.text).status).to.be.eq('ok');
+        expect(JSON.parse(res.text).credentials).to.be.undefined;
+        expect(rpMockup.calledOnce).to.be.true;
+        expect(rpMockup.args[0][0].uri).to.include('/v1/feed_destinations/42/credentials');
+        expect(rpMockup.args[0][0].method).to.be.eq('POST');
+        done();
+      });
+  });
+
+  it('should not call upsertFeedDestinationCredentials when feed_destination_id is absent', function (done) {
+    const rpMockup: sinon.SinonStub = sinon.stub().returns(Promise.resolve({}));
+    const plugin = new MyFakeAudienceFeedConnectorWithOAuth(false);
+    const runner = new core.TestingPluginRunner(plugin, rpMockup);
+
+    const req: ExternalSegmentAuthenticationRequest = {
+      user_id: 'user1',
+      plugin_version_id: '99',
+      params: { code: 'auth-code', state: 'some-state' },
+    };
+
+    void request(runner.plugin.app)
+      .post('/v1/authentication')
+      .send(req)
+      .end(function (err, res) {
+        expect(res.status).to.equal(200);
+        expect(rpMockup.called).to.be.false;
+        done();
+      });
+  });
+
+  it('should return 500 when feed_destination_id is present but plugin returns no credentials', function (done) {
+    const rpMockup: sinon.SinonStub = sinon.stub().returns(Promise.resolve({}));
+    const plugin = new MyFakeAudienceFeedConnectorWithOAuthNoCredentials(false);
+    const runner = new core.TestingPluginRunner(plugin, rpMockup);
+
+    const req: ExternalSegmentAuthenticationRequest = {
+      user_id: 'user1',
+      plugin_version_id: '99',
+      feed_destination_id: '42',
+      params: { code: 'auth-code', state: '42' },
+    };
+
+    void request(runner.plugin.app)
+      .post('/v1/authentication')
+      .send(req)
+      .end(function (err, res) {
+        expect(res.status).to.equal(500);
+        expect(JSON.parse(res.text).message).to.include('refresh_token');
         done();
       });
   });

--- a/src/tests/AudienceFeedConnector.ts
+++ b/src/tests/AudienceFeedConnector.ts
@@ -12,7 +12,11 @@ import { AudienceFeedBatchContext, UserSegmentUpdatePluginFileDeliveryResponseDa
 import { BatchUpdateRequest } from '../mediarithmics/api/core/batchupdate/BatchUpdateInterface';
 import {
   TestAuthenticationPluginResponse,
+} from '../mediarithmics/api/plugin/audiencefeedconnector/AudienceFeedConnectorPluginResponseInterface';
+import {
   TestAuthenticationRequest,
+} from '../mediarithmics/api/plugin/audiencefeedconnector/AudienceFeedConnectorRequestInterface';
+import {
   FeedDestinationCredentials,
 } from '../mediarithmics';
 
@@ -163,6 +167,25 @@ describe('Check Destination Credentials', function () {
         expect(JSON.parse(res.text).status).to.be.eq('not_implemented');
         done();
       });
+  });
+});
+
+describe('upsertFeedDestinationCredentials', function () {
+  it('should POST to the correct URL with credentials', function (done) {
+    const rpMockup: sinon.SinonStub = sinon.stub().returns(Promise.resolve({}));
+    const plugin = new MyFakeAudienceFeedConnector(false);
+    new core.TestingPluginRunner(plugin, rpMockup);
+
+    void plugin.upsertFeedDestinationCredentials('42', {
+      scheme: 'OAUTH2',
+      credentials: { refresh_token: 'my-token' },
+    }).then(() => {
+      expect(rpMockup.args[0][0].uri).to.be.eq(
+        `${plugin.outboundPlatformUrl}/v1/feed_destinations/42/credentials`,
+      );
+      expect(rpMockup.args[0][0].method).to.be.eq('POST');
+      done();
+    });
   });
 });
 


### PR DESCRIPTION
…nationCredentials helper

Adds POST /v1/test_authentication route to AudienceFeedConnectorBasePlugin, allowing the platform to trigger a credentials test. The plugin fetches credentials via fetchFeedDestinationCredentials() and delegates to onTestAuthentication(). If credentials cannot be fetched, returns an error with HTTP 500.