### PR TITLE
MICS-24964 Add empty status to dynamic property values query response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # Unreleased
 
+- `AudienceFeedConnectorDynamicPropertyValuesQueryStatus` now supports `'empty'` status in `onDynamicPropertyValuesQuery`
+  - Use it when a dynamic property has no available options
+  - Return `{ status: 'empty', message: 'Reason why the field is empty' }` to display an explanatory message to the user
+
 # 0.38.0 2026-03-31
 
 - Update dependencies, mainly mocha. The min nodejs version is now 20.19.0.

--- a/src/mediarithmics/api/plugin/audiencefeedconnector/AudienceFeedConnectorPluginResponseInterface.ts
+++ b/src/mediarithmics/api/plugin/audiencefeedconnector/AudienceFeedConnectorPluginResponseInterface.ts
@@ -10,7 +10,7 @@ export declare type AudienceFeedConnectorAuthenticationStatus =
   | 'not_implemented';
 export declare type AudienceFeedAuthenticationStatus = 'ok' | 'error' | 'not_implemented';
 export declare type AudienceFeedLogoutStatus = 'ok' | 'error' | 'not_implemented';
-export declare type AudienceFeedConnectorDynamicPropertyValuesQueryStatus = 'ok' | 'error' | 'not_implemented';
+export declare type AudienceFeedConnectorDynamicPropertyValuesQueryStatus = 'ok' | 'error' | 'empty' | 'not_implemented';
 export type AudienceFeedConnectorContentType = 'text/csv' | 'application/json' | 'text/plain';
 
 export interface UserSegmentUpdatePluginResponse {

--- a/src/mediarithmics/plugins/audience-feed-connector/AudienceFeedConnectorBasePlugin.ts
+++ b/src/mediarithmics/plugins/audience-feed-connector/AudienceFeedConnectorBasePlugin.ts
@@ -546,6 +546,7 @@ abstract class GenericAudienceFeedConnectorBasePlugin<
           let statusCode: number;
           switch (response.status) {
             case 'ok':
+            case 'empty':
               statusCode = 200;
               break;
             case 'error':


### PR DESCRIPTION
Plugins need to signal that a property has no options without treating it as an error.