### PR TITLE
MICS-25441 Increase payload size limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # Unreleased
 
+- Increase size limit for incoming payloads
+
 # 0.40.0 2026-04-30
 
 - Add optional `feed_destination_id` to `UserSegmentUpdateRequest`, `ExternalSegmentConnectionRequest`, `ExternalSegmentCreationRequest`, and `ExternalSegmentAuthenticationRequest`

--- a/src/mediarithmics/plugins/common/BasePlugin.ts
+++ b/src/mediarithmics/plugins/common/BasePlugin.ts
@@ -210,8 +210,8 @@ export abstract class BasePlugin<CacheValue = unknown> {
       });
     }
 
-    this.app.use(bodyParser.raw({ type: 'application/ion', limit: '5mb' }));
-    this.app.use(bodyParser.json({ type: '*/*', limit: '5mb' }));
+    this.app.use(bodyParser.raw({ type: 'application/ion', limit: '12mb' }));
+    this.app.use(bodyParser.json({ type: '*/*', limit: '12mb' }));
 
     this.logger = winston.createLogger({
       transports: [


### PR DESCRIPTION
We hit the limit of 5mb when pushing large batches to the "/batch_update" route.
Since we can't really reduce the size of data pushed by the platform (without impacting the plugin's perf), we increase the accepted size of the payload.
Batch files seem to be limited to ~9-10Mb, so let's push it to 12Mb here.