### PR TITLE
MICS-25518 Distinguish invalid credentials (HTTP 401) from operationa…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # Unreleased
 
+- `onTestAuthentication` now supports the `'invalid_credentials'` status, mapped to HTTP 401, to distinguish invalid credentials from operational errors (`'error'` → HTTP 500)
+
 # 0.40.1 2026-05-28
 
 - Increase size limit for incoming payloads

--- a/examples/audience-feed/src/ExampleAudienceFeed.ts
+++ b/examples/audience-feed/src/ExampleAudienceFeed.ts
@@ -193,10 +193,18 @@ export class ExampleAudienceFeed extends core.BatchedAudienceFeedConnectorBasePl
   ): Promise<core.TestAuthenticationPluginResponse> {
     // Use the credentials fetched from TenantCredentials to test the connection.
     // credentials.credentials contains the data stored during onAuthentication (e.g. refresh_token).
-    if (credentials && credentials.credentials) {
-      return Promise.resolve({ status: 'ok' });
+    if (!credentials || !credentials.credentials) {
+      // No credentials stored / cannot perform the check -> operational error (HTTP 500)
+      return Promise.resolve({ status: 'error', message: 'No credentials found' });
     }
-    return Promise.resolve({ status: 'error', message: 'No credentials found' });
+    // Call the external system with the credentials. If it rejects them -> invalid_credentials
+    // (HTTP 401), which is distinct from an operational error (HTTP 500).
+    const areCredentialsValid = true; // replace with the real check against the destination
+    return Promise.resolve(
+      areCredentialsValid
+        ? { status: 'ok' }
+        : { status: 'invalid_credentials', message: 'Credentials rejected by the destination' },
+    );
   }
 
   protected onLogout(request: core.ExternalSegmentLogoutRequest): Promise<core.ExternalSegmentLogoutResponse> {

--- a/src/mediarithmics/api/plugin/audiencefeedconnector/AudienceFeedConnectorPluginResponseInterface.ts
+++ b/src/mediarithmics/api/plugin/audiencefeedconnector/AudienceFeedConnectorPluginResponseInterface.ts
@@ -107,7 +107,7 @@ export interface CreateOAuthRedirectUrlPluginResponse {
   login_url: string;
 }
 
-export type TestAuthenticationStatus = 'ok' | 'error' | 'not_implemented';
+export type TestAuthenticationStatus = 'ok' | 'invalid_credentials' | 'error' | 'not_implemented';
 
 export interface TestAuthenticationPluginResponse {
   status: TestAuthenticationStatus;

--- a/src/mediarithmics/plugins/audience-feed-connector/AudienceFeedConnectorBasePlugin.ts
+++ b/src/mediarithmics/plugins/audience-feed-connector/AudienceFeedConnectorBasePlugin.ts
@@ -629,6 +629,9 @@ abstract class GenericAudienceFeedConnectorBasePlugin<
             case 'ok':
               statusCode = 200;
               break;
+            case 'invalid_credentials':
+              statusCode = 401;
+              break;
             case 'error':
               statusCode = 500;
               break;

--- a/src/tests/AudienceFeedConnector.ts
+++ b/src/tests/AudienceFeedConnector.ts
@@ -104,6 +104,15 @@ class MyFakeAudienceFeedConnectorWithCredentialsCheck extends core.AudienceFeedC
   }
 }
 
+class MyFakeAudienceFeedConnectorWithInvalidCredentials extends MyFakeAudienceFeedConnectorWithCredentialsCheck {
+  protected onTestAuthentication(
+    request: TestAuthenticationRequest,
+    credentials: FeedDestinationCredentials,
+  ): Promise<TestAuthenticationPluginResponse> {
+    return Promise.resolve({ status: 'invalid_credentials', message: 'Invalid credentials' });
+  }
+}
+
 describe('Check Destination Credentials', function () {
   it('should return error (500) when no credentials are stored', function (done) {
     const rpMockup: sinon.SinonStub = sinon.stub().rejects(new Error('Not Found'));
@@ -145,6 +154,29 @@ describe('Check Destination Credentials', function () {
         expect(rpMockup.args[0][0].uri).to.be.eq(
           `${runner.plugin.outboundPlatformUrl}/v1/feed_destinations/42/credentials`,
         );
+        done();
+      });
+  });
+
+  it('should return invalid_credentials (401) when onTestAuthentication rejects the credentials', function (done) {
+    const credentials: FeedDestinationCredentials = {
+      scheme: 'API_TOKEN',
+      credentials: { token: 'bad-token' },
+    };
+
+    const rpMockup: sinon.SinonStub = sinon.stub().returns(Promise.resolve({ status: 'ok', data: credentials }));
+
+    const plugin = new MyFakeAudienceFeedConnectorWithInvalidCredentials(false);
+    const runner = new core.TestingPluginRunner(plugin, rpMockup);
+
+    const checkRequest: TestAuthenticationRequest = { feed_destination_id: '42' };
+
+    void request(runner.plugin.app)
+      .post('/v1/test_authentication')
+      .send(checkRequest)
+      .end(function (err, res) {
+        expect(res.status).to.equal(401);
+        expect(JSON.parse(res.text).status).to.be.eq('invalid_credentials');
         done();
       });
   });


### PR DESCRIPTION
…l errors in test_authentication

onTestAuthentication can now return status 'invalid_credentials', mapped to HTTP 401, so callers distinguish a credential rejection from an operational error (500). ok->200, error->500, not_implemented->400 unchanged. Example connector and tests updated.