### PR TITLE
MICS-25577 Pass feed destination credentials to audience feed plugin …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # Unreleased
 
+- Fetch the feed destination credentials when a request carries `feed_destination_id`, and pass them to `onUserSegmentUpdate()`, `onTroubleshoot()`, `onDynamicPropertyValuesQuery()` and the instance context builder, so plugins can use the vault credentials and fall back to their legacy credentials
+- Add optional `feed_destination_id` to `AudienceFeedBatchContext`, `ExternalSegmentTroubleshootRequest` and `ExternalSegmentDynamicPropertyValuesQueryRequest`
+- Rename `getFeedDestinationCredentialsCached()` to `getFeedDestinationCredentials()`
+
 # 0.40.2 2026-06-09
 
 - `onTestAuthentication` now supports the `'invalid_credentials'` status, mapped to HTTP 401, to distinguish invalid credentials from operational errors (`'error'` → HTTP 500)

--- a/package-lock.json
+++ b/package-lock.json
@@ -2201,15 +2201,15 @@
       }
     },
     "node_modules/form-data": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.5.tgz",
-      "integrity": "sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.6.tgz",
+      "integrity": "sha512-Ogz/E85h9tlfJzpI6TuFpGcHZFhLrb9Gw8wq9v40CxSCPnv7ahKr6Xgtkn0KYCDQJ8DNn5VoMO8EXr9V5PadyA==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
+        "hasown": "^2.0.4",
         "mime-types": "^2.1.35",
         "safe-buffer": "^5.2.1"
       },
@@ -2533,9 +2533,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"

--- a/src/mediarithmics/api/plugin/audiencefeedconnector/AudienceFeedConnectorRequestInterface.ts
+++ b/src/mediarithmics/api/plugin/audiencefeedconnector/AudienceFeedConnectorRequestInterface.ts
@@ -11,6 +11,7 @@ export interface UserSegmentUpdateRequest {
   datamart_id: string;
   segment_id: string;
   feed_destination_id?: string;
+  preset_id?: string;
   user_identifiers: UserIdentifierInfo[];
   user_profiles: UserProfileInfo[];
   ts: number;
@@ -38,6 +39,7 @@ export interface AudienceFeedBatchContext extends BatchUpdateContext {
   segment_id: string;
   datamart_id: string;
   grouping_key: string;
+  feed_destination_id?: string;
 }
 
 export const ExternalSegmentTroubleshootActions = ['FETCH_DESTINATION_AUDIENCE'] as const;
@@ -47,6 +49,7 @@ type ExternalSegmentTroubleshootBaseRequest = {
   feed_id: string;
   datamart_id: string;
   segment_id: string;
+  feed_destination_id?: string;
 };
 
 export type TroubleshootActionFetchDestinationAudience = ExternalSegmentTroubleshootBaseRequest & {
@@ -88,6 +91,7 @@ export interface ExternalSegmentDynamicPropertyValuesQueryRequest {
   datamart_id: string;
   user_id: string;
   properties?: PluginProperty[];
+  feed_destination_id?: string;
 }
 
 export interface TestAuthenticationRequest {

--- a/src/mediarithmics/plugins/audience-feed-connector/AudienceFeedConnectorBasePlugin.ts
+++ b/src/mediarithmics/plugins/audience-feed-connector/AudienceFeedConnectorBasePlugin.ts
@@ -51,7 +51,7 @@ import {
   ExternalSegmentTroubleshootRequest,
   UserSegmentUpdateRequest,
 } from '../../api/plugin/audiencefeedconnector/AudienceFeedConnectorRequestInterface';
-import { BasePlugin, PropertiesWrapper } from '../common';
+import { BasePlugin, PropertiesWrapper, ResourceNotFoundError } from '../common';
 
 export interface AudienceFeedConnectorBaseInstanceContext {
   feed: AudienceSegmentExternalFeedResource;
@@ -137,6 +137,20 @@ abstract class GenericAudienceFeedConnectorBasePlugin<
     return response.data;
   }
 
+  async fetchFeedDestinationCredentialsOptional(
+    feedDestinationId: string,
+  ): Promise<FeedDestinationCredentials | undefined> {
+    try {
+      return await this.fetchFeedDestinationCredentials(feedDestinationId);
+    } catch (e) {
+      if (e instanceof ResourceNotFoundError) {
+        this.logger.debug(`No credentials found for feed destination: ${feedDestinationId}`);
+        return undefined;
+      }
+      throw e;
+    }
+  }
+
   async upsertFeedDestinationCredentials(
     feedDestinationId: string,
     credentials: FeedDestinationCredentials,
@@ -171,7 +185,10 @@ abstract class GenericAudienceFeedConnectorBasePlugin<
   }
 
   // This is a default provided implementation
-  protected async instanceContextBuilder(feedId: string): Promise<AudienceFeedConnectorBaseInstanceContext> {
+  protected async instanceContextBuilder(
+    feedId: string,
+    feedDestinationCredentials?: FeedDestinationCredentials,
+  ): Promise<AudienceFeedConnectorBaseInstanceContext> {
     const audienceFeedP = this.fetchAudienceFeed(feedId);
     const audienceFeedPropsP = this.fetchAudienceFeedProperties(feedId);
 
@@ -201,11 +218,13 @@ abstract class GenericAudienceFeedConnectorBasePlugin<
   protected abstract onUserSegmentUpdate(
     request: UserSegmentUpdateRequest,
     instanceContext: AudienceFeedConnectorBaseInstanceContext,
+    feedDestinationCredentials?: FeedDestinationCredentials,
   ): Promise<R>;
 
   protected onTroubleshoot(
     request: ExternalSegmentTroubleshootRequest,
     instanceContext: AudienceFeedConnectorBaseInstanceContext,
+    feedDestinationCredentials?: FeedDestinationCredentials,
   ): Promise<ExternalSegmentTroubleshootResponse> {
     return Promise.resolve({ status: 'not_implemented' });
   }
@@ -228,6 +247,7 @@ abstract class GenericAudienceFeedConnectorBasePlugin<
 
   protected onDynamicPropertyValuesQuery(
     request: ExternalSegmentDynamicPropertyValuesQueryRequest,
+    feedDestinationCredentials?: FeedDestinationCredentials,
   ): Promise<ExternalSegmentDynamicPropertyValuesQueryResponse> {
     return Promise.resolve({ status: 'not_implemented' });
   }
@@ -248,11 +268,12 @@ abstract class GenericAudienceFeedConnectorBasePlugin<
   protected async getInstanceContext(
     feedId: string,
     forceRefresh?: boolean,
+    feedDestinationCredentials?: FeedDestinationCredentials,
   ): Promise<AudienceFeedConnectorBaseInstanceContext> {
     if (forceRefresh || !this.pluginCache.get(feedId)) {
       void this.pluginCache.put(
         feedId,
-        this.instanceContextBuilder(feedId).catch((error) => {
+        this.instanceContextBuilder(feedId, feedDestinationCredentials).catch((error) => {
           this.logger.error(`Error while caching instance context`, error);
           this.pluginCache.del(feedId);
           throw error;
@@ -261,6 +282,22 @@ abstract class GenericAudienceFeedConnectorBasePlugin<
       );
     }
     return this.pluginCache.get(feedId) as Promise<AudienceFeedConnectorBaseInstanceContext>;
+  }
+
+  async getFeedDestinationCredentials(feedDestinationId: string): Promise<FeedDestinationCredentials | undefined> {
+    const cacheKey = `feed_destination_credentials:${feedDestinationId}`;
+    if (!this.pluginCache.get(cacheKey)) {
+      void this.pluginCache.put(
+        cacheKey,
+        this.fetchFeedDestinationCredentialsOptional(feedDestinationId).catch((error) => {
+          this.logger.error(`Error while caching feed destination credentials`, error);
+          this.pluginCache.del(cacheKey);
+          throw error;
+        }) as unknown as Promise<AudienceFeedConnectorBaseInstanceContext>,
+        this.getInstanceContextCacheExpiration(),
+      );
+    }
+    return this.pluginCache.get(cacheKey) as unknown as Promise<FeedDestinationCredentials | undefined>;
   }
 
   protected emptyBodyFilter = (req: express.Request, res: express.Response, next: express.NextFunction) => {
@@ -273,7 +310,7 @@ abstract class GenericAudienceFeedConnectorBasePlugin<
     } else {
       next();
     }
-  }
+  };
 
   private initExternalSegmentCreation(): void {
     this.app.post(
@@ -293,7 +330,11 @@ abstract class GenericAudienceFeedConnectorBasePlugin<
             throw new Error('No External Segment Creation listener registered!');
           }
 
-          const instanceContext = await this.getInstanceContext(request.feed_id, true);
+          const feedDestinationCredentials = request.feed_destination_id
+            ? await this.getFeedDestinationCredentials(request.feed_destination_id)
+            : undefined;
+
+          const instanceContext = await this.getInstanceContext(request.feed_id, true, feedDestinationCredentials);
 
           const response = await this.onExternalSegmentCreation(request, instanceContext);
 
@@ -344,7 +385,11 @@ abstract class GenericAudienceFeedConnectorBasePlugin<
             throw new Error('No External Segment Connection listener registered!');
           }
 
-          const instanceContext = await this.getInstanceContext(request.feed_id);
+          const feedDestinationCredentials = request.feed_destination_id
+            ? await this.getFeedDestinationCredentials(request.feed_destination_id)
+            : undefined;
+
+          const instanceContext = await this.getInstanceContext(request.feed_id, false, feedDestinationCredentials);
 
           const response = await this.onExternalSegmentConnection(request, instanceContext);
 
@@ -399,9 +444,13 @@ abstract class GenericAudienceFeedConnectorBasePlugin<
             throw new Error('No User Segment Update listener registered!');
           }
 
-          const instanceContext = await this.getInstanceContext(request.feed_id);
+          const feedDestinationCredentials = request.feed_destination_id
+            ? await this.getFeedDestinationCredentials(request.feed_destination_id)
+            : undefined;
 
-          const response: R = await this.onUserSegmentUpdate(request, instanceContext);
+          const instanceContext = await this.getInstanceContext(request.feed_id, false, feedDestinationCredentials);
+
+          const response: R = await this.onUserSegmentUpdate(request, instanceContext, feedDestinationCredentials);
 
           if (response.next_msg_delay_in_ms) {
             res.set('x-mics-next-msg-delay', response.next_msg_delay_in_ms.toString());
@@ -453,9 +502,13 @@ abstract class GenericAudienceFeedConnectorBasePlugin<
           return res.status(400).send(JSON.stringify(response));
         }
 
-        const instanceContext = await this.getInstanceContext(request.feed_id);
+        const feedDestinationCredentials = request.feed_destination_id
+          ? await this.getFeedDestinationCredentials(request.feed_destination_id)
+          : undefined;
 
-        const response = await this.onTroubleshoot(request, instanceContext);
+        const instanceContext = await this.getInstanceContext(request.feed_id, false, feedDestinationCredentials);
+
+        const response = await this.onTroubleshoot(request, instanceContext, feedDestinationCredentials);
 
         let statusCode: number;
         switch (response.status) {
@@ -528,9 +581,7 @@ abstract class GenericAudienceFeedConnectorBasePlugin<
 
         if (request.feed_destination_id && response.status === 'ok') {
           if (!response.refresh_token) {
-            throw new Error(
-              `Plugin must return a refresh_token when feed_destination_id is present`,
-            );
+            throw new Error(`Plugin must return a refresh_token when feed_destination_id is present`);
           }
           await this.upsertFeedDestinationCredentials(request.feed_destination_id, {
             scheme: 'OAUTH2',
@@ -682,9 +733,7 @@ abstract class GenericAudienceFeedConnectorBasePlugin<
             );
           }
 
-          this.logger.debug(
-            `FeedDestinationId: ${request.feed_destination_id} - OAuth redirect URL generated`,
-          );
+          this.logger.debug(`FeedDestinationId: ${request.feed_destination_id} - OAuth redirect URL generated`);
 
           return res.status(200).send(JSON.stringify(response));
         } catch (error) {
@@ -702,7 +751,10 @@ abstract class GenericAudienceFeedConnectorBasePlugin<
       async (req: express.Request, res: express.Response) => {
         try {
           const request = req.body as ExternalSegmentDynamicPropertyValuesQueryRequest;
-          const response = await this.onDynamicPropertyValuesQuery(request);
+          const feedDestinationCredentials = request.feed_destination_id
+            ? await this.getFeedDestinationCredentials(request.feed_destination_id)
+            : undefined;
+          const response = await this.onDynamicPropertyValuesQuery(request, feedDestinationCredentials);
           let statusCode: number;
           switch (response.status) {
             case 'ok':
@@ -748,7 +800,10 @@ export abstract class BatchedAudienceFeedConnectorBasePlugin<T> extends GenericA
     );
 
     batchUpdateHandler.registerRoute(async (request) => {
-      const instanceContext = await this.getInstanceContext(request.context.feed_id);
+      const feedDestinationCredentials = request.context.feed_destination_id
+        ? await this.getFeedDestinationCredentials(request.context.feed_destination_id)
+        : undefined;
+      const instanceContext = await this.getInstanceContext(request.context.feed_id, false, feedDestinationCredentials);
       return this.onBatchUpdate(request, instanceContext);
     });
   }

--- a/src/tests/AudienceFeedConnector.ts
+++ b/src/tests/AudienceFeedConnector.ts
@@ -19,9 +19,7 @@ import {
   ExternalSegmentAuthenticationRequest,
   TestAuthenticationRequest,
 } from '../mediarithmics/api/plugin/audiencefeedconnector/AudienceFeedConnectorRequestInterface';
-import {
-  FeedDestinationCredentials,
-} from '../mediarithmics';
+import { FeedDestinationCredentials } from '../mediarithmics';
 
 const PLUGIN_AUTHENTICATION_TOKEN = 'Manny';
 const PLUGIN_WORKER_ID = 'Calavera';
@@ -433,16 +431,16 @@ describe('upsertFeedDestinationCredentials', function () {
     const plugin = new MyFakeAudienceFeedConnector(false);
     new core.TestingPluginRunner(plugin, rpMockup);
 
-    void plugin.upsertFeedDestinationCredentials('42', {
-      scheme: 'OAUTH2',
-      credentials: { refresh_token: 'my-token' },
-    }).then(() => {
-      expect(rpMockup.args[0][0].uri).to.be.eq(
-        `${plugin.outboundPlatformUrl}/v1/feed_destinations/42/credentials`,
-      );
-      expect(rpMockup.args[0][0].method).to.be.eq('POST');
-      done();
-    });
+    void plugin
+      .upsertFeedDestinationCredentials('42', {
+        scheme: 'OAUTH2',
+        credentials: { refresh_token: 'my-token' },
+      })
+      .then(() => {
+        expect(rpMockup.args[0][0].uri).to.be.eq(`${plugin.outboundPlatformUrl}/v1/feed_destinations/42/credentials`);
+        expect(rpMockup.args[0][0].method).to.be.eq('POST');
+        done();
+      });
   });
 });
 
@@ -658,5 +656,195 @@ describe('External Audience Feed API test', function () {
   afterEach(() => {
     // We clear the cache so that we don't have any processing still running in the background
     runner.plugin.pluginCache.clear();
+  });
+});
+
+class CapturingAudienceFeedConnector extends core.AudienceFeedConnectorBasePlugin {
+  public capturedFeedDestinationCredentials?: FeedDestinationCredentials;
+  public onUserSegmentUpdateCalled = false;
+  public onTroubleshootCalled = false;
+
+  protected onExternalSegmentCreation(): Promise<core.ExternalSegmentCreationPluginResponse> {
+    return Promise.resolve({ status: 'ok' });
+  }
+
+  protected onExternalSegmentConnection(): Promise<core.ExternalSegmentConnectionPluginResponse> {
+    return Promise.resolve({ status: 'ok' });
+  }
+
+  protected onUserSegmentUpdate(
+    request: core.UserSegmentUpdateRequest,
+    instanceContext: core.AudienceFeedConnectorBaseInstanceContext,
+    feedDestinationCredentials?: FeedDestinationCredentials,
+  ): Promise<core.UserSegmentUpdatePluginResponse> {
+    this.onUserSegmentUpdateCalled = true;
+    this.capturedFeedDestinationCredentials = feedDestinationCredentials;
+    return Promise.resolve({ status: 'ok' });
+  }
+
+  protected onTroubleshoot(
+    request: core.ExternalSegmentTroubleshootRequest,
+    instanceContext: core.AudienceFeedConnectorBaseInstanceContext,
+    feedDestinationCredentials?: FeedDestinationCredentials,
+  ): Promise<core.ExternalSegmentTroubleshootResponse> {
+    this.onTroubleshootCalled = true;
+    this.capturedFeedDestinationCredentials = feedDestinationCredentials;
+    return Promise.resolve({ status: 'ok' });
+  }
+}
+
+describe('Live path feed destination credentials', function () {
+  const feedId = '512';
+
+  const feedResponse: core.DataResponse<core.AudienceSegmentExternalFeedResource> = {
+    status: 'ok',
+    data: {
+      id: feedId,
+      plugin_id: '984',
+      organisation_id: '95',
+      group_id: 'com.mediarithmics.audience-feed',
+      artifact_id: 'awesome-audience-feed',
+      version_id: '1254',
+    },
+  };
+
+  const propertiesResponse: core.DataListResponse<core.PluginProperty> = { status: 'ok', count: 0, data: [] };
+
+  function userSegmentUpdateRequest(feedDestinationId?: string): core.UserSegmentUpdateRequest {
+    return {
+      feed_id: feedId,
+      session_id: 'session',
+      datamart_id: '1023',
+      segment_id: '451256',
+      user_identifiers: [],
+      user_profiles: [],
+      ts: 1,
+      operation: 'UPSERT',
+      feed_destination_id: feedDestinationId,
+    };
+  }
+
+  function buildRunner(plugin: CapturingAudienceFeedConnector, credentialsImpl: () => Promise<unknown>) {
+    const credentialsCall = sinon.spy(credentialsImpl);
+    const rpMockup: sinon.SinonStub = sinon.stub();
+    rpMockup
+      .withArgs(
+        sinon.match.has(
+          'uri',
+          sinon.match((value: string) => /\/v1\/audience_segment_external_feeds\/(.){1,10}$/.test(value)),
+        ),
+      )
+      .returns(Promise.resolve(feedResponse));
+    rpMockup
+      .withArgs(
+        sinon.match.has(
+          'uri',
+          sinon.match((value: string) => /\/v1\/audience_segment_external_feeds\/(.){1,10}\/properties/.test(value)),
+        ),
+      )
+      .returns(Promise.resolve(propertiesResponse));
+    rpMockup
+      .withArgs(
+        sinon.match.has(
+          'uri',
+          sinon.match((value: string) => /\/v1\/feed_destinations\/(.+)\/credentials/.test(value)),
+        ),
+      )
+      .callsFake(credentialsCall);
+    return { runner: new core.TestingPluginRunner(plugin, rpMockup), credentialsCall };
+  }
+
+  it('passes vault credentials to the handler when the request has feed_destination_id', function (done) {
+    const credentials: FeedDestinationCredentials = { scheme: 'API_TOKEN', credentials: { token: 'secret' } };
+    const plugin = new CapturingAudienceFeedConnector(false);
+    const { runner } = buildRunner(plugin, () => Promise.resolve({ status: 'ok', data: credentials }));
+
+    void request(runner.plugin.app)
+      .post('/v1/user_segment_update')
+      .send(userSegmentUpdateRequest('42'))
+      .end(function (err, res) {
+        expect(res.status).to.equal(200);
+        expect(plugin.capturedFeedDestinationCredentials).to.deep.equal(credentials);
+        runner.plugin.pluginCache.clear();
+        done();
+      });
+  });
+
+  it('passes undefined credentials to the handler when the vault returns 404', function (done) {
+    const notFound = { name: 'StatusCodeError', response: { statusCode: 404, statusMessage: 'Not Found', body: {} } };
+    const plugin = new CapturingAudienceFeedConnector(false);
+    const { runner } = buildRunner(plugin, () => Promise.reject(notFound));
+
+    void request(runner.plugin.app)
+      .post('/v1/user_segment_update')
+      .send(userSegmentUpdateRequest('42'))
+      .end(function (err, res) {
+        expect(res.status).to.equal(200);
+        expect(plugin.onUserSegmentUpdateCalled).to.be.true;
+        expect(plugin.capturedFeedDestinationCredentials).to.be.undefined;
+        runner.plugin.pluginCache.clear();
+        done();
+      });
+  });
+
+  it('does not fetch credentials when the request has no feed_destination_id', function (done) {
+    const plugin = new CapturingAudienceFeedConnector(false);
+    const { runner, credentialsCall } = buildRunner(plugin, () => Promise.resolve({ status: 'ok', data: {} }));
+
+    void request(runner.plugin.app)
+      .post('/v1/user_segment_update')
+      .send(userSegmentUpdateRequest(undefined))
+      .end(function (err, res) {
+        expect(res.status).to.equal(200);
+        expect(plugin.onUserSegmentUpdateCalled).to.be.true;
+        expect(plugin.capturedFeedDestinationCredentials).to.be.undefined;
+        expect(credentialsCall.called).to.be.false;
+        runner.plugin.pluginCache.clear();
+        done();
+      });
+  });
+
+  function troubleshootRequest(feedDestinationId?: string): core.ExternalSegmentTroubleshootRequest {
+    return {
+      feed_id: feedId,
+      datamart_id: '1023',
+      segment_id: '451256',
+      action: 'FETCH_DESTINATION_AUDIENCE',
+      feed_destination_id: feedDestinationId,
+    };
+  }
+
+  it('passes vault credentials to the troubleshoot handler when the request has feed_destination_id', function (done) {
+    const credentials: FeedDestinationCredentials = { scheme: 'API_TOKEN', credentials: { token: 'secret' } };
+    const plugin = new CapturingAudienceFeedConnector(false);
+    const { runner } = buildRunner(plugin, () => Promise.resolve({ status: 'ok', data: credentials }));
+
+    void request(runner.plugin.app)
+      .post('/v1/troubleshoot')
+      .send(troubleshootRequest('42'))
+      .end(function (err, res) {
+        expect(res.status).to.equal(200);
+        expect(plugin.onTroubleshootCalled).to.be.true;
+        expect(plugin.capturedFeedDestinationCredentials).to.deep.equal(credentials);
+        runner.plugin.pluginCache.clear();
+        done();
+      });
+  });
+
+  it('does not fetch credentials for troubleshoot when the request has no feed_destination_id', function (done) {
+    const plugin = new CapturingAudienceFeedConnector(false);
+    const { runner, credentialsCall } = buildRunner(plugin, () => Promise.resolve({ status: 'ok', data: {} }));
+
+    void request(runner.plugin.app)
+      .post('/v1/troubleshoot')
+      .send(troubleshootRequest(undefined))
+      .end(function (err, res) {
+        expect(res.status).to.equal(200);
+        expect(plugin.onTroubleshootCalled).to.be.true;
+        expect(plugin.capturedFeedDestinationCredentials).to.be.undefined;
+        expect(credentialsCall.called).to.be.false;
+        runner.plugin.pluginCache.clear();
+        done();
+      });
   });
 });


### PR DESCRIPTION
…handlers

When a request carries feed_destination_id, the SDK fetches the destination credentials (cached, 404-tolerant) and passes them to onUserSegmentUpdate, onTroubleshoot, onDynamicPropertyValuesQuery and the instance context builder.

Plugins receive the vault credentials as an optional argument and can use them or fall back to their legacy credentials. Renames getFeedDestinationCredentialsCached to getFeedDestinationCredentials.